### PR TITLE
[#7] Use setuptools to run default test. Remove twisted. Add coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ install:
   - pip install --extra-index-url http://chevah.com/pypi/simple -e .[dev]
 
 script:
-  - python `which nose_runner.py` - chevah/keycert/tests
-  - pocketlint chevah/keycert
+  - python setup.py test -q
+
+after_success:
+  - coveralls
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
 
 install:
-  - pip install --extra-index-url http://chevah.com/pypi/simple -e .[dev]
+  - pip install --extra-index-url http://chevah.com/pypi/simple --trusted-host chevah.com -e .[dev]
 
 script:
   - python setup.py test -q

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for Chevah KeyCert project.
 #
-PYPI_INDEX='http://chevah.com/pypi/simple'
+EXTRA_PYPI_INDEX='http://chevah.com/pypi/simple'
 UNAME=`uname`
 ifeq "$(UNAME)" "mingw"
        BASE_PATH='build/venv/Scripts/'
@@ -18,7 +18,7 @@ env:
 
 deps: env
 	@$(BASE_PATH)/pip install \
-		--extra-index-url ${PYPI_INDEX}\
+		--extra-index-url ${EXTRA_PYPI_INDEX}\
 		--download-cache __pycache__\
 		-e .[dev]
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ env:
 
 deps: env
 	@$(BASE_PATH)/pip install \
-		-i ${PYPI_INDEX}\
+		--extra-index-url ${PYPI_INDEX}\
 		--download-cache __pycache__\
 		-e .[dev]
 
@@ -37,7 +37,7 @@ lint:
 	@echo "All good."
 
 test:
-	@$(BASE_PATH)/python build/venv/bin/nose_runner.py - chevah/keycert/tests
+	@$(BASE_PATH)/nosetests --with-coverage --cover-package=chevah.keycert --cover-erase --cover-test
 	@echo -n "Running linter..."
 	@$(BASE_PATH)/pyflakes chevah/keycert/
 	@$(BASE_PATH)/pep8 --hang-closing chevah/keycert/

--- a/README.rst
+++ b/README.rst
@@ -3,13 +3,14 @@ chevah-keycert
 
 SSH Keys and SSL certificates handling.
 
-Build development environment::
+Build development environment and activate it::
 
     make deps
+    . build/venv/bin/activate
 
-Run tests::
+Run default tests::
 
-    make test
+    python setup.py test
 
 Default virtual environment is created in build/venv.
 
@@ -30,7 +31,16 @@ It provides the following functionalities:
 SSH key handling is based on Twisted code, but project no longer depend
 on Twisted.
 
+MIT License.
+
 Release is done automatically for each tag, using Travis-CI.
+
+.. image:: https://pypip.in/version/chevah-keycert/badge.svg
+    :target: https://pypi.python.org/pypi/chevah-keycert/
+    :alt: Latest Version
 
 .. image:: https://travis-ci.org/chevah/chevah-keycert.svg?branch=master
     :target: https://travis-ci.org/chevah/chevah-keycert
+
+.. image:: https://img.shields.io/coveralls/chevah/chevah-keycert/master.svg
+    :target: https://coveralls.io/r/chevah/chevah-keycert?branch=master

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@ class NoseTestCommand(TestCommand):
         import nose
         from pocketlint.formatcheck import main as pocket_main
 
-        module = 'chevah.keycert'
         nose_args = ['nosetests']
         if self.verbose:
             nose_args.append('-v')
         else:
             nose_args.append('-q')
 
+        module = self.test_suite
         if self.test_module:
             module = self.test_module
 
@@ -87,12 +87,12 @@ setup(
         'pyopenssl ==0.13',
         'pyCrypto ==2.6.1',
         'pyasn1 ==0.1.7',
-        'chevah-compat ==0.27.0',
+        'chevah-compat ==0.27.1',
         ],
 
     extras_require={
         'dev': [
-            'chevah-empirical ==0.33.0',
+            'chevah-empirical ==0.33.1',
             'pyflakes ==0.8.1',
             'pocketlint ==1.4.4.c10',
             'pep8 ==1.6.1',
@@ -104,5 +104,5 @@ setup(
             ],
         },
     cmdclass={'test': NoseTestCommand},
-    test_suite='chevah.keycert.tests',
+    test_suite='chevah.keycert',
     )

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,54 @@
-from setuptools import setup, find_packages
+import sys
 from codecs import open
 from os import path
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 
 VERSION = '1.0.1'
+
+
+class NoseTestCommand(TestCommand):
+
+    def run_tests(self):
+        """
+        Run nose with default arguments.
+        """
+        import nose
+        from pocketlint.formatcheck import main as pocket_main
+
+        module = 'chevah.keycert'
+        nose_args = ['nosetests']
+        if self.verbose:
+            nose_args.append('-v')
+        else:
+            nose_args.append('-q')
+
+        if self.test_module:
+            module = self.test_module
+
+        nose_args.extend([
+            '--with-coverage',
+            '--cover-package=' + module,
+            '--cover-erase',
+            '--cover-test',
+            module.replace('.', '/'),
+            ])
+
+        pocket_args = [
+            'chevah/keycert',
+            'README.rst',
+            'setup.py',
+            ]
+
+        nose_code = nose.run(argv=nose_args)
+        if nose_code:
+            nose_code = 0
+        else:
+            nose_code = 1
+
+        pocket_code = pocket_main(pocket_args)
+        sys.exit(pocket_code or nose_code)
+
 
 here = path.abspath(path.dirname(__file__))
 
@@ -41,20 +87,22 @@ setup(
         'pyopenssl ==0.13',
         'pyCrypto ==2.6.1',
         'pyasn1 ==0.1.7',
-        'chevah-compat ==0.25.2',
+        'chevah-compat ==0.27.0',
         ],
 
     extras_require={
         'dev': [
-            'twisted >=12.1.0',
-            'chevah-empirical ==0.32.2',
+            'chevah-empirical ==0.33.0',
             'pyflakes ==0.8.1',
-            'pocketlint ==1.4.4.c9',
+            'pocketlint ==1.4.4.c10',
             'pep8 ==1.6.1',
             'nose',
             'mock',
             'bunch',
+            'coverage',
+            'coveralls',
             ],
         },
+    cmdclass={'test': NoseTestCommand},
     test_suite='chevah.keycert.tests',
     )


### PR DESCRIPTION
Problem
======

We want to completly remove twisted, event from test suite.
We want to run tests using the default python setup.py test
We want to have coverage reports.

Changes
=======

Update compat and empirical to not depend on twisted.
Update setup.py to run a default nose / pocketlint tests.
Update travis build to send coverage results.
