### PR TITLE
_fromString_OPENSSH_PRIVATE leave the key empty when unknown type is loaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,5 @@ dist-clean: clean
 	@rm -rf __pycache__
 
 
-lint:
-	@echo -n "Running linter..."
-	@$(BASE_PATH)/pocketlint chevah/keycert/
-	@echo "All good."
-
 test:
-	@$(BASE_PATH)/nosetests --with-coverage --cover-package=chevah.keycert --cover-erase --cover-test
-	@echo -n "Running linter..."
-	@$(BASE_PATH)/pyflakes chevah/keycert/
-	@$(BASE_PATH)/pep8 --hang-closing chevah/keycert/
-	@echo "All good."
+	@$(BASE_PATH)/python setup.py test

--- a/chevah/keycert/common.py
+++ b/chevah/keycert/common.py
@@ -25,7 +25,7 @@ def getNS(s, count=1):
     ns = []
     c = 0
     for i in range(count):
-        l, = struct.unpack('!L', s[c:c+4])
+        l, = struct.unpack('!L', s[c:c + 4])
         ns.append(s[c + 4:4 + l + c])
         c += 4 + l
     return tuple(ns) + (s[c:],)

--- a/chevah/keycert/tests/keydata.py
+++ b/chevah/keycert/tests/keydata.py
@@ -123,6 +123,49 @@ CfI51GQLw7pUPeO2WNt6yZO/YkzZrqvTj5FEwybkUyBv7L0gkqu9wjfDdUw0fVHE
 xEm4DxjEoaIp8dW/JOzXQ2EF+WaSOgdYsw3Ac+rnnjnNptCdOEDGP6QBkt+oXj4P
 -----END RSA PRIVATE KEY-----"""
 
+publicECDSA_256_openssh = (
+    'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBB'
+    'OjYtJiozMWSwCHHuy45Pz0kSmMnKtcEk25JDxejWstEfOylLKJlDDL3fgDwOmwUROShOQAOIH'
+    '/OdOZb2Ra9PwE='
+    )
+
+privateECDSA_256_openssh = """\
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIFmPW4WLKcDp6VobtNvI7tuiQAPVceeiqRdO2jqH5DFPoAoGCCqGSM49
+AwEHoUQDQgAE6Ni0mKjMxZLAIce7Ljk/PSRKYycq1wSTbkkPF6Nay0R87KUsomUM
+Mvd+APA6bBRE5KE5AA4gf8505lvZFr0/AQ==
+-----END EC PRIVATE KEY-----"""
+
+publicECDSA_384_openssh = (
+    'ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhB'
+    'NOGQOVM5kkTGgWN6q9L2bRrH6z9mQm9wGBoD5tCdslcxASbBqj2qTBHCvmhOTAicWPMdyznO5'
+    '7YhPfhmz1Io41NL4atvupVdfE9VZWh41E2fgKOuMaCvQKozYOH453avg=='
+    )
+
+privateECDSA_384_openssh = """\
+-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDAa1OmNBtHBS9OePf7SasIXd4jfTC1u3GV/GRKiAy0+cB0mInLat3iW
+iJ9IuQxNWHigBwYFK4EEACKhZANiAATThkDlTOZJExoFjeqvS9m0ax+s/ZkJvcBg
+aA+bQnbJXMQEmwao9qkwRwr5oTkwInFjzHcs5zue2IT34Zs9SKONTS+Grb7qVXXx
+PVWVoeNRNn4CjrjGgr0CqM2Dh+Od2r4=
+-----END EC PRIVATE KEY-----"""
+
+publicECDSA_521_openssh = (
+    'ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFB'
+    'ACZW5+0ETwFP7RB1LExhorCGs3943r7jqb8iVU9pReaUwHmGQ+JAxR0MXwFUUDKcEKCa+Jx1C'
+    'z7o1CFeB3vl6J+2QFLT+ZLC9KjMlkgQki6PQQyi8UySk8ErW6JB8XLU6AA1RYZfcyqv3lcg/4'
+    'YgxI4ngMvyxOdZSB2LiIjfRqNam6U5w=='
+    )
+
+privateECDSA_521_openssh = """\
+-----BEGIN EC PRIVATE KEY-----
+MIHbAgEBBEH3+zGR/FmfnxV/KNTK79rbn8+p0pj1alib1mZ6dqrCzPUWuFfTAPyL
+1j+Zw+lFFrf3a/V883JaX3iycsFoyeGaa6AHBgUrgQQAI6GBiQOBhgAEAJlbn7QR
+PAU/tEHUsTGGisIazf3jevuOpvyJVT2lF5pTAeYZD4kDFHQxfAVRQMpwQoJr4nHU
+LPujUIV4He+Xon7ZAUtP5ksL0qMyWSBCSLo9BDKLxTJKTwStbokHxctToADVFhl9
+zKq/eVyD/hiDEjieAy/LE51lIHYuIiN9Go1qbpTn
+-----END EC PRIVATE KEY-----"""
+
 publicRSA_lsh = (
     "{KDEwOnB1YmxpYy1rZXkoMTQ6cnNhLXBrY3MxLXNoYTEoMTpuOTc6AK8yc"
     "fDmDpyZs3+LXwRLy4vA1T6yd/3PZNiPwM+uH8Yx3/YpskSW4sbUIZR/ZXzY1CMfuC5qyR+UD"
@@ -218,10 +261,3 @@ privateDSA_agentv3 = (
     "\x16\x84,O\x97\x1d\xfa\xb6l\xcf_r@\xf1\xd8R\xceH\x82s\xcb\xcd\xd5\x99"
     "\x00\x00\x00\x15\x00\x97T\xeavi@\x1b\xf6\xf8\x9eu\\\x84h\x8e\xf6\xc3\x0b"
     "\xf0\xc3")
-
-__all__ = [
-    'DSAData', 'RSAData', 'privateDSA_agentv3', 'privateDSA_lsh',
-    'privateDSA_openssh', 'privateRSA_agentv3', 'privateRSA_lsh',
-    'privateRSA_openssh', 'publicDSA_lsh', 'publicDSA_openssh',
-    'publicRSA_lsh', 'publicRSA_openssh', 'privateRSA_openssh_alternate',
-    ]

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -711,11 +711,35 @@ class TestKey(EmpiricalTestCase):
 
         self.assertEqual('private_openssh', result)
 
+    def test_guessStringType_private_OpenSSH_ECDSA(self):
+        """
+        Can recognize an OpenSSH ECDSA private key.
+        """
+        result = Key._guessStringType(keydata.privateECDSA_256_openssh)
+
+        self.assertEqual('private_openssh', result)
+
     def test_guessStringType_public_OpenSSH(self):
         """
         Can recognize an OpenSSH public key.
         """
         result = Key._guessStringType(OPENSSH_RSA_PUBLIC)
+
+        self.assertEqual('public_openssh', result)
+
+    def test_guessStringType_public_OpenSSH_ECDSA(self):
+        """
+        Can recognize an OpenSSH public key.
+        """
+        result = Key._guessStringType(keydata.publicECDSA_256_openssh)
+
+        self.assertEqual('public_openssh', result)
+
+        result = Key._guessStringType(keydata.publicECDSA_384_openssh)
+
+        self.assertEqual('public_openssh', result)
+
+        result = Key._guessStringType(keydata.publicECDSA_521_openssh)
 
         self.assertEqual('public_openssh', result)
 
@@ -1382,6 +1406,15 @@ AAAAB3NzaC1yc2EA
 
         self.checkParsedDSAPrivate1024(sut)
 
+    def test_fromString_PRIVATE_OPENSSH_ECDSA(self):
+        """
+        Can not load a private OPENSSH ECDSA.
+        """
+        self.assertBadKey(
+            keydata.privateECDSA_256_openssh,
+            'Key type EC not supported.'
+            )
+
     def test_fromString_PRIVATE_OPENSSH_short(self):
         """
         Raise an error when private OpenSSH key is too short.
@@ -1734,7 +1767,7 @@ IGNORED
         self.assertRaises(
             keys.BadKeyError,
             keys.Key.fromString,
-            data='{'+base64.encodestring(sexp)+'}')
+            data='{' + base64.encodestring(sexp) + '}')
 
         sexp = sexpy.pack([['private-key', ['bad-key', ['p', '2']]]])
         self.assertRaises(
@@ -1773,7 +1806,7 @@ IGNORED
         self.assertRaises(
             keys.BadKeyError,
             keys.Key.fromString,
-            '\x00\x00\x00\x07ssh-foo'+'\x00\x00\x00\x01\x01'*5)
+            '\x00\x00\x00\x07ssh-foo' + '\x00\x00\x00\x01\x01' * 5)
 
     def test_sign(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
+import os
 import sys
 from codecs import open
-from os import path
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -35,10 +36,12 @@ class NoseTestCommand(TestCommand):
             ])
 
         pocket_args = [
-            'chevah/keycert',
             'README.rst',
             'setup.py',
             ]
+        for root, dirs, files in os.walk('chevah/keycert', topdown=False):
+            for name in files:
+                pocket_args.append(os.path.join(root, name))
 
         nose_code = nose.run(argv=nose_args)
         if nose_code:
@@ -47,12 +50,15 @@ class NoseTestCommand(TestCommand):
             nose_code = 1
 
         pocket_code = pocket_main(pocket_args)
+        if not pocket_code:
+            print('Linter OK')
+
         sys.exit(pocket_code or nose_code)
 
 
-here = path.abspath(path.dirname(__file__))
+here = os.path.abspath(os.path.dirname(__file__))
 
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
For example if we load a ECDSA or PEM certificate, no error is raises and key is None.

It was fixed by raised an error when loading an unknown type for private SSH key.

support for ECDSA will be added later.