### PR TITLE
Add support for argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ script:
 after_success:
   - coveralls
 
+# Only run test when committing to master branch.
+# PR tests will still be executed.
+branches:
+  only:
+    - master
+
 deploy:
   provider: pypi
   user: chevah-robot

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,15 +1,18 @@
 Create issues and send pull requests.
 
+All changes need to have tests.
+All test code need to have 100% coverage.
+
 Build development environment and activate it::
 
     make deps
     . build/venv/bin/activate
 
-Run default tests, linters and coverage::
+Run checks exceuted on Travis-CI: test, linters and coverage::
 
     python setup.py test
 
-To also get HTML coverage report use::
+To get HTML coverage report use::
 
     make test
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ Build development environment and activate it::
     make deps
     . build/venv/bin/activate
 
-Run checks exceuted on Travis-CI: test, linters and coverage::
+Run checks executed on Travis-CI: test, linters and coverage::
 
     python setup.py test
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,18 @@
+Create issues and send pull requests.
+
+Build development environment and activate it::
+
+    make deps
+    . build/venv/bin/activate
+
+Run default tests, linters and coverage::
+
+    python setup.py test
+
+To also get HTML coverage report use::
+
+    make test
+
+Default virtual environment is created in build/venv.
+
+Use nosetests for TDD.

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,12 @@ all: test
 
 env:
 	@if [ ! -d "build/venv" ]; then virtualenv build/venv; fi
+	@$(BASE_PATH)/pip install -U pip
 
 
 deps: env
 	@$(BASE_PATH)/pip install \
 		--extra-index-url ${EXTRA_PYPI_INDEX}\
-		--download-cache __pycache__\
 		-e .[dev]
 
 
@@ -27,9 +27,7 @@ clean:
 	@rm -rf build
 
 
-dist-clean: clean
-	@rm -rf __pycache__
-
-
 test:
-	@$(BASE_PATH)/python setup.py test
+	@$(BASE_PATH)/python setup.py test -q
+	@echo "See HTML coverate in build/cover"
+	@coverage html -d build/cover/

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ env:
 deps: env
 	@$(BASE_PATH)/pip install \
 		--extra-index-url ${EXTRA_PYPI_INDEX}\
+		--trusted-host chevah.com \
 		-e .[dev]
 
 

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,12 @@
 chevah-keycert
 ==============
 
-SSH Keys and SSL certificates handling.
+SSH Keys and SSL key/csr/certificates handling.
 
-Build development environment and activate it::
+The functions are designed to integrate with command line tools but also with
+other user interfaces (for example from a web based control panel).
 
-    make deps
-    . build/venv/bin/activate
-
-Run default tests::
-
-    python setup.py test
-
-Default virtual environment is created in build/venv.
-
-This SSH key handling is based on twisted.conch.ssh.key but it was forked
-to not depend on Twisted.
-
-It still depends on these C modules:
+It depends on these C modules:
 
 * pyCrypto
 * pyOpenSSL
@@ -25,11 +14,12 @@ It still depends on these C modules:
 It provides the following functionalities:
 
 * Generate self signed SSL certificate.
-* Generate RSA/DSA keys
-* Convert OpenSSH, SSH.com, Putty, LSH
+* Generate RSA/DSA keys.
+* Convert OpenSSH, SSH.com, Putty, LSH.
+* Populate an argparser subparser with command line options.
 
-SSH key handling is based on Twisted code, but project no longer depend
-on Twisted.
+The SSH key handling was forked from Twisted code, but project no longer
+depends on Twisted.
 
 MIT License.
 

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -55,9 +55,44 @@ class KeyCertException(Exception):
     """
 
 
+def generate_ssh_key_subparser(
+        subparsers, name, default_key_size=2048, default_key_type='rsa'):
+    """
+    Create an argparse sub-command with `name` attached to `subparsers`.
+    """
+    generate_ssh_key = subparsers.add_parser(
+        name,
+        help='Create a SSH public and private key pair.',
+        )
+    generate_ssh_key.add_argument(
+        '--key-file',
+        metavar='FILE',
+        help=(
+            'Store the keys pair in FILE and FILE.pub. Default id_TYPE.'),
+        )
+    generate_ssh_key.add_argument(
+        '--key-size',
+        metavar="SIZE", default=default_key_size,
+        help='Generate a RSA or DSA key of size SIZE. Default %(default)s',
+        )
+    generate_ssh_key.add_argument(
+        '--key-type',
+        metavar="[rsa|dsa]", default=default_key_type,
+        help='Generate a DSA or RSA key. Default %(default)s.',
+        )
+    generate_ssh_key.add_argument(
+        '--key-comment',
+        metavar="COMMENT_TEXT",
+        help=(
+            'Generate the public key using this comment. Default no comment.'),
+        )
+
+
 def generate_ssh_key(options, open_method=None):
     """
     Generate a SSH RSA or DSA key and store it on disk.
+
+    `options` is an argparse namespace. See `generate_ssh_key_subparser`.
 
     Return a pair of (exit_code, operation_message).
 
@@ -67,7 +102,7 @@ def generate_ssh_key(options, open_method=None):
     """
     key = None
 
-    if open_method is None:
+    if open_method is None:  # pragma: no cover
         open_method = open
 
     exit_code = 0
@@ -178,7 +213,7 @@ class Key(object):
     """
 
     @staticmethod
-    def secureRandom(n):
+    def secureRandom(n):  # pragma: no cover
         return rand.bytes(n)
 
     def __init__(self, keyObject):

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -99,7 +99,7 @@ def generate_ssh_key(options, open_method=None):
 
     `options` is an argparse namespace. See `generate_ssh_key_subparser`.
 
-    Return a tupple of (exit_code, operation_message, key).
+    Return a tuple of (exit_code, operation_message, key).
 
     For success, exit_code is 0.
 

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -72,7 +72,7 @@ def generate_ssh_key_subparser(
         )
     generate_ssh_key.add_argument(
         '--key-size',
-        metavar="SIZE", default=default_key_size,
+        type=int, metavar="SIZE", default=default_key_size,
         help='Generate a RSA or DSA key of size SIZE. Default %(default)s',
         )
     generate_ssh_key.add_argument(
@@ -86,6 +86,12 @@ def generate_ssh_key_subparser(
         help=(
             'Generate the public key using this comment. Default no comment.'),
         )
+    generate_ssh_key.add_argument(
+        '--key-skip',
+        action='store_true', default=False,
+        help='Do not create a new key if a key file already exists.',
+        )
+
 
 
 def generate_ssh_key(options, open_method=None):
@@ -94,7 +100,7 @@ def generate_ssh_key(options, open_method=None):
 
     `options` is an argparse namespace. See `generate_ssh_key_subparser`.
 
-    Return a pair of (exit_code, operation_message).
+    Return a tupple of (exit_code, operation_message, key).
 
     For success, exit_code is 0.
 
@@ -189,7 +195,7 @@ def _skip_key_generation(options, private_file, public_file):
     """
     private_segments = local_filesystem.getSegmentsFromRealPath(private_file)
     if local_filesystem.exists(private_segments):
-        if options.migrate:
+        if options.key_skip:
             return True
         else:
             raise KeyCertException(
@@ -198,6 +204,7 @@ def _skip_key_generation(options, private_file, public_file):
     public_segments = local_filesystem.getSegmentsFromRealPath(public_file)
     if local_filesystem.exists(public_segments):
         raise KeyCertException(u'Public key already exists. %s' % public_file)
+    return False
 
 
 class Key(object):

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -93,7 +93,6 @@ def generate_ssh_key_subparser(
         )
 
 
-
 def generate_ssh_key(options, open_method=None):
     """
     Generate a SSH RSA or DSA key and store it on disk.

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -246,7 +246,7 @@ class CommandLineMixin(object):
             sys.stdout = self.stdout
             sys.stderr = self.stderr
             return self.parser.parse_args(args)
-        except SystemExit as error:
+        except SystemExit as error:  # pragma: no cover
             raise AssertionError(
                 'Fail to parse %s\n-- stdout --\n%s\n-- stderr --\n%s' % (
                     error.code,
@@ -1754,27 +1754,6 @@ class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
         """
         namespace = Namespace(**expected)
         self.assertEqual(namespace, actual)
-
-    def parseArguments(self, args):
-        """
-        Parse arguments and capture stdout.
-        """
-        self.stdout = StringIO()
-        self.stderr = StringIO()
-        try:
-            sys.stdout = self.stdout
-            sys.stderr = self.stderr
-            return self.parser.parse_args(args)
-        except SystemExit as error:  # pragma: no cover
-            raise AssertionError(
-                'Fail to parse %s\n-- stdout --\n%s\n-- stderr --\n%s' % (
-                    error.code,
-                    self.stdout.getvalue(),
-                    self.stderr.getvalue(),
-                    ))
-        finally:
-            sys.stdout = sys.__stdout__
-            sys.stderr = sys.__stderr__
 
     def test_default(self):
         """

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -1765,7 +1765,7 @@ class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
             sys.stdout = self.stdout
             sys.stderr = self.stderr
             return self.parser.parse_args(args)
-        except SystemExit as error:
+        except SystemExit as error:  # pragma: no cover
             raise AssertionError(
                 'Fail to parse %s\n-- stdout --\n%s\n-- stderr --\n%s' % (
                     error.code,

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -1,0 +1,26 @@
+"""
+Demo command line for chevah-keycert.
+"""
+# Fix namespaced package import.
+import chevah
+import os
+chevah.__path__.insert(0, os.path.join(os.getcwd(), 'chevah'))
+
+import argparse
+import sys
+from chevah.keycert.ssh import (
+    generate_ssh_key,
+    generate_ssh_key_subparser,
+    )
+
+parser = argparse.ArgumentParser(prog='PROG', prefix_chars='-+')
+subparser = parser.add_subparsers(
+            help='Available sub-commands', dest='sub_command')
+
+generate_ssh_key_subparser(subparser, 'gen-ssh-key')
+
+options = parser.parse_args()
+if options.sub_command == 'gen-ssh-key':
+    exit, message, _ = generate_ssh_key(options)
+    sys.stdout.write(message)
+    sys.exit(exit)

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Relese notes for Chevah KeyCert
 ###############################
 
 
+1.2.0 - 03/04/2015
+==================
+
+* Add helper to populate argparse sub-command for ssh key generation.
+
+
 1.1.0 - 15/02/2015
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import os
 import sys
 from codecs import open
+from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -54,7 +55,17 @@ class NoseTestCommand(TestCommand):
         if not pocket_code:
             print('Linter OK')
 
-        sys.exit(pocket_code or nose_code)
+        coverage_args = [
+            'report',
+            '--include=chevah/keycert/tests/*',
+            '--fail-under=100',
+            ]
+        covergate_code = load_entry_point(
+            'coverage', 'console_scripts', 'coverage')(argv=coverage_args)
+        if not covergate_code:
+            print('Tests coverage OK')
+
+        sys.exit(pocket_code or nose_code or covergate_code)
 
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from codecs import open
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.1.0'
+VERSION = '1.2.0'
 
 
 class NoseTestCommand(TestCommand):


### PR DESCRIPTION
Problem
======

The `generate_ssh_key` function expect a default 
each command should allow create a subcomand for argparse

Changes
=======

Added a helper to populate arg parser.

Update test and write tests with better integration.

I have also cleaned a bit the documentation and added a demo tool.


How to test
=========

reviewers: @alibotean 

check that changes make sense