### PR TITLE
Create a SSL CSR

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,6 +3,8 @@ Create issues and send pull requests.
 All changes need to have tests.
 All test code need to have 100% coverage.
 
+Auto-released on PyPi using Travis-CI for each tag.
+
 Build development environment and activate it::
 
     make deps

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,8 @@ It depends on these C modules:
 
 It provides the following functionalities:
 
-* Generate self signed SSL certificate.
+* Generate SSL key and self signed SSL certificate.
+* Generate SSL key and CSR.
 * Generate RSA/DSA keys.
 * Convert OpenSSH, SSH.com, Putty, LSH.
 * Populate an argparser subparser with command line options.

--- a/chevah/keycert/exceptions.py
+++ b/chevah/keycert/exceptions.py
@@ -4,6 +4,7 @@
 Public exceptions raised by this package.
 """
 
+
 class KeyCertException(Exception):
     """
     Generic exception raised by the package.
@@ -12,4 +13,4 @@ class KeyCertException(Exception):
         self.message = message
 
     def __str__(self):
-        return self.message
+        return self.message.encode('utf-8')

--- a/chevah/keycert/exceptions.py
+++ b/chevah/keycert/exceptions.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2014 Adi Roiban.
+# See LICENSE for details.
+"""
+Public exceptions raised by this package.
+"""
+
+class KeyCertException(Exception):
+    """
+    Generic exception raised by the package.
+    """
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message

--- a/chevah/keycert/sexpy.py
+++ b/chevah/keycert/sexpy.py
@@ -33,7 +33,7 @@ def parse(s):
         data = s[i + 1:i + 1 + length]
         expr[-1].append(data)
         s = s[i + 1 + length:]
-    assert 0, "this should not happen"
+    assert 0, "this should not happen"   # pragma: no cover
 
 
 def pack(sexp):

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -91,6 +91,7 @@ def generate_ssh_key_subparser(
         action='store_true', default=False,
         help='Do not create a new key if a key file already exists.',
         )
+    return generate_ssh_key
 
 
 def generate_ssh_key(options, open_method=None):

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011 Adi Roiban.
+# Copyright (c) 2015 Adi Roiban.
 # See LICENSE for details.
 """
 SSL keys and certificates.
@@ -6,6 +6,10 @@ SSL keys and certificates.
 from socket import gethostname
 
 from OpenSSL import crypto
+
+_DEFAULT_SSL_KEY_CYPHER = b'aes-256-cbc'
+
+from chevah.keycert.exceptions import KeyCertException
 
 
 def generate_ssl_self_signed_certificate():
@@ -35,3 +39,212 @@ def generate_ssl_self_signed_certificate():
     certificate_pem = crypto.dump_certificate(crypto.FILETYPE_PEM, cert)
     key_pem = crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
     return (certificate_pem, key_pem)
+
+
+def generate_ssl_key_certificate_signing_request_subparser(
+        subparsers, name, default_key_size=2048, default_key_type='rsa'):
+    """
+    Create an argparse sub-command for generating CSR options with
+    `name` attached to `subparsers`.
+    """
+    sub_command = subparsers.add_parser(
+        name,
+        help=(
+            'Create a SSL private key and associated certificate '
+            'signing request.'),
+        )
+    sub_command.add_argument(
+        '--common-name',
+        help='Common name associated with the generated CSR.',
+        required=True,
+        )
+    sub_command.add_argument(
+        '--key-file',
+        metavar="FILE",
+        default='server.key',
+        help=(
+            'Store the keys/csr pair in FILE and FILE.csr. '
+            'Private key stored using PEM PKCS#8 format. '
+            'CSR file stored in PEM x509 format. '
+            'Default server.key and server.csr.'),
+        )
+    sub_command.add_argument(
+        '--key-size',
+        type=int, metavar="SIZE", default=default_key_size,
+        help='Generate a RSA or DSA key of size SIZE. Default %(default)s',
+        )
+    sub_command.add_argument(
+        '--key-type',
+        metavar="[rsa|dsa]", default=default_key_type,
+        help='Generate a DSA or RSA key. Default %(default)s.',
+        )
+    sub_command.add_argument(
+        '--key-password',
+        metavar="PASSPHRASE",
+        help=(
+            'Password used to encrypt the generated key. '
+            'Default no encryption. Encrypted with %s.' % (
+                _DEFAULT_SSL_KEY_CYPHER,)),
+        )
+    sub_command.add_argument(
+        '--email',
+        help='Email address used by the requested command.',
+        )
+    sub_command.add_argument(
+        '--alternative-name',
+        help='Optional list of alternative name of the generated CSR.',
+        )
+    sub_command.add_argument(
+        '--organization',
+        help='Organization associated with the generated CSR.',
+        )
+    sub_command.add_argument(
+        '--organization-unit',
+        help='Organization unit associated with the generated CSR.',
+        )
+    sub_command.add_argument(
+        '--locality',
+        help='Full name location associated with the generated CSR.',
+        )
+    sub_command.add_argument(
+        '--state',
+        help=(
+            'Full name of the state/county/region associated with the '
+            'generated CSR.'),
+        )
+    sub_command.add_argument(
+        '--country',
+        help=(
+            'Two letter code of the country associated with the '
+            'generated CSR.'),
+        )
+    return sub_command
+
+
+def generate_csr(options):
+    """
+    Generate a new SSL key and the associated SSL cert signing.
+
+    Returns a tuple of (csr_pem, key_pem)
+    Raise KeyCertException on failure.
+    """
+    try:
+        return _generate_csr(options)
+    except crypto.Error as error:
+        try:
+            message = 'Error: %s' % (error[0][0][2],)
+        except IndexError:
+            message = 'Error: no error details.'
+        raise KeyCertException(message)
+
+
+def _generate_csr(options):
+    """
+    Helper to catch all crypto errors and reduce indentation.
+    """
+    key_type = options.key_type.lower()
+
+    if key_type == 'dsa':
+        key_type = crypto.TYPE_DSA
+    elif key_type == 'rsa':
+        key_type = crypto.TYPE_RSA
+    else:
+        key_type = 'not-suppored'
+
+    csr = crypto.X509Req()
+    subject = csr.get_subject()
+
+    if options.common_name:
+        subject.commonName = options.common_name.encode('idna')
+
+    if options.organization:
+        subject.organizationName = options.organization
+
+    if options.organization_unit:
+        subject.organizationalUnitName = options.organization_unit
+
+    if options.locality:
+        subject.localityName = options.locality
+
+    if options.state:
+        subject.stateOrProvinceName = options.state
+
+    if options.country:
+        subject.countryName = options.country
+
+    if options.email:
+        subject.emailAddress = options.email.encode('idna')
+
+    # We create a CSR which can not be used as a CA, but designated to be
+    # used as server certificate.
+    keyusage = (
+        b'digitalSignature, nonRepudiation, keyEncipherment, keyAgreement')
+    extensions = [
+        crypto.X509Extension(b'basicConstraints', False, b'CA:FALSE'),
+        crypto.X509Extension(b'keyUsage', False, keyusage),
+        crypto.X509Extension(b'extendedKeyUsage', False, b'serverAuth'),
+        ]
+
+    # Alternate name is optional.
+    if options.alternative_name:
+        extensions.append(crypto.X509Extension(
+            b'subjectAltName',
+            False,
+            options.alternative_name.encode('idna')))
+
+    key = crypto.PKey()
+    key.generate_key(key_type, options.key_size)
+
+    csr.add_extensions(extensions)
+    csr.set_pubkey(key)
+    csr.sign(key, 'sha256')
+
+    csr_pem = crypto.dump_certificate_request(crypto.FILETYPE_PEM, csr)
+    if options.key_password:
+        key_pem = crypto.dump_privatekey(
+            crypto.FILETYPE_PEM, key,
+            _DEFAULT_SSL_KEY_CYPHER, options.key_password.encode('utf-8'))
+    else:
+        key_pem = crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
+
+    return {
+        'csr_pem': csr_pem,
+        'csr_key': key_pem,
+        'csr': csr,
+        'key': key,
+        }
+
+
+def generate_and_store_csr(options):
+    """
+    Generate a key/csr and try to store it on disk.
+    """
+    key_segments = local_filesystem.getSegmentsFromRealPath(options.key_file)
+    name, _ = os.path.splitext(key_segments[-1])
+    csr_name = u'%s.csr' % name
+    csr_segments = key_segments[:-1]
+    csr_segments.append(csr_name)
+
+    if local_filesystem.exists(key_segments):
+        return (1, 'Key file already exists')
+
+    try:
+        csr, key = generate_csr(options)
+    except KeyCertException as error:
+        return (1, error.message)
+
+    store_file = None
+    try:
+        store_file = local_filesystem.openFileForWriting(key_segments)
+        store_file.write(key)
+    finally:
+        if store_file:
+            store_file.close()
+    store_file = None
+    try:
+        store_file = local_filesystem.openFileForWriting(csr_segments)
+        store_file.write(csr)
+    finally:
+        if store_file:
+            store_file.close()
+    return (0, 'Key and CSR successfully created.')

--- a/chevah/keycert/tests/helpers.py
+++ b/chevah/keycert/tests/helpers.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2015 Adi Roiban.
+# See LICENSE for details.
+"""
+Helpers for testing the project.
+"""
+from argparse import Namespace
+from StringIO import StringIO
+import sys
+
+
+class CommandLineMixin(object):
+    """
+    Helper to test command line tools.
+    """
+    def parseArguments(self, args):
+        """
+        Parse arguments and return options and captured stdout.
+        """
+        stdout = StringIO()
+        stderr = StringIO()
+        prev_stdout = sys.stdout
+        prev_stderr = sys.stderr
+        try:
+            sys.stdout = stdout
+            sys.stderr = stderr
+            options = self.parser.parse_args(args)
+            return options
+        except SystemExit as error:  # pragma: no cover
+            raise AssertionError(
+                'Fail to parse %s\n-- stdout --\n%s\n-- stderr --\n%s' % (
+                    error.code,
+                    stdout.getvalue(),
+                    stderr.getvalue(),
+                    ))
+        finally:
+            # We don't revert to sys.__stdout__ and the test runner might
+            # have injected its logger.
+            sys.stdout = prev_stdout
+            sys.stderr = prev_stderr
+
+    def parseArgumentsFailure(self, args):
+        """
+        Parse arguments and capture exit_code and stderr.
+        """
+        stdout = StringIO()
+        stderr = StringIO()
+        prev_stdout = sys.stdout
+        prev_stderr = sys.stderr
+        try:
+            sys.stdout = stdout
+            sys.stderr = stderr
+            self.parser.parse_args(args)
+            raise AssertionError(   # pragma: no cover
+                'Failure not triggered when parsing the arguments.')
+        except SystemExit as error:
+            return error.code, stderr.getvalue()
+        finally:
+            # We don't revert to sys.__stdout__ and the test runner might
+            # have injected its logger.
+            sys.stdout = prev_stdout
+            sys.stderr = prev_stderr
+
+    def assertNamespaceEqual(self, expected, actual):
+        """
+        Check that namespaces are equal.
+        """
+        namespace = Namespace(**expected)
+        self.assertEqual(namespace, actual)

--- a/chevah/keycert/tests/test_exceptions.py
+++ b/chevah/keycert/tests/test_exceptions.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2015 Adi Roiban.
+# See LICENSE for details.
+"""
+Test for exceptions raise by this package.
+"""
+from chevah.empirical import mk, EmpiricalTestCase
+
+from chevah.keycert.exceptions import KeyCertException
+
+
+class TestExceptions(EmpiricalTestCase):
+    """
+    Test for exceptions
+    """
+
+    def test_KeyCertException(self):
+        """
+        It provides a message.
+        """
+        message = mk.string()
+
+        error = KeyCertException(message)
+
+        self.assertEqual(message, error.message)
+
+    def test_KeyCertException_str(self):
+        """
+        The message is the string serialization.
+        """
+        message = mk.string()
+
+        error = KeyCertException(message)
+
+        self.assertEqual(message.encode('utf-8'), str(error))

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -1741,7 +1741,7 @@ class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
 
     def test_value(self):
         """
-        Options are parsed form command line.
+        Options are parsed from the command line.
         """
         generate_ssh_key_subparser(self.subparser, 'key-gen')
 

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -26,6 +26,7 @@ from chevah.keycert.ssh import (
     generate_ssh_key_subparser,
     )
 from chevah.keycert.tests import keydata
+from chevah.keycert.tests.helpers import CommandLineMixin
 
 PUBLIC_RSA_ARMOR_START = u'-----BEGIN PUBLIC KEY-----\n'
 PUBLIC_RSA_ARMOR_END = u'\n-----END PUBLIC KEY-----\n'
@@ -230,32 +231,6 @@ class DummyOpenContext(object):
 
     def __exit__(self, exc_type, exc_value, tb):
         return False
-
-
-class CommandLineMixin(object):
-    """
-    Helper to test command line tools.
-    """
-    def parseArguments(self, args):
-        """
-        Parse arguments and capture stdout.
-        """
-        self.stdout = StringIO()
-        self.stderr = StringIO()
-        try:
-            sys.stdout = self.stdout
-            sys.stderr = self.stderr
-            return self.parser.parse_args(args)
-        except SystemExit as error:  # pragma: no cover
-            raise AssertionError(
-                'Fail to parse %s\n-- stdout --\n%s\n-- stderr --\n%s' % (
-                    error.code,
-                    self.stdout.getvalue(),
-                    self.stderr.getvalue(),
-                    ))
-        finally:
-            sys.stdout = sys.__stdout__
-            sys.stderr = sys.__stderr__
 
 
 class TestHelpers(EmpiricalTestCase, CommandLineMixin):
@@ -1747,13 +1722,6 @@ class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
         self.parser = ArgumentParser(prog='test-command')
         self.subparser = self.parser.add_subparsers(
             help='Available sub-commands', dest='sub_command')
-
-    def assertNamespaceEqual(self, expected, actual):
-        """
-        Check that namespaces are equal.
-        """
-        namespace = Namespace(**expected)
-        self.assertEqual(namespace, actual)
 
     def test_default(self):
         """

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -4,11 +4,10 @@
 """
 Test for SSH keys management.
 """
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 from hashlib import sha1
 from StringIO import StringIO
 import base64
-import sys
 import textwrap
 
 from chevah.empirical import mk, EmpiricalTestCase

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -82,7 +82,7 @@ class Test_generate_csr_parser(
 
     def test_default(self):
         """
-        It can be initiaized with only a subparser and sub-command name.
+        It can be initialized with only a subparser and sub-command name.
         """
         generate_csr_parser(self.subparser, 'key-gen')
 
@@ -213,7 +213,7 @@ class Test_generate_csr(CommandLineTestBase):
 
         self.assertEqual('key size too small', context.exception.message)
 
-    def test_bad_county_long(self):
+    def test_bad_country_long(self):
         """
         Raise an exception when country code is not correct.
         """
@@ -228,7 +228,7 @@ class Test_generate_csr(CommandLineTestBase):
 
         self.assertEqual('string too long', context.exception.message)
 
-    def test_bad_county_short(self):
+    def test_bad_country_short(self):
         """
         Raise an exception when country code is not correct.
         """
@@ -276,7 +276,7 @@ class Test_generate_csr(CommandLineTestBase):
 
     def test_gen_unicode(self):
         """
-        Domains are encoded using IDNA and names using unicode.
+        Domains are encoded using IDNA and names using Unicode.
         """
         options = self.parseArguments([
             self.command_name,
@@ -309,7 +309,7 @@ class Test_generate_csr(CommandLineTestBase):
 
     def test_encrypted_key(self):
         """
-        When asked it serialized the key with a password.
+        When asked it will serialize the key with a password.
         """
         options = self.parseArguments([
             self.command_name,

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -3,26 +3,65 @@
 """
 Test for SSL keys/cert management.
 """
-from argparse import ArgumentParser, Namespace
-from hashlib import sha1
-from StringIO import StringIO
-import base64
-import sys
-import textwrap
+from argparse import ArgumentParser
 
 from chevah.empirical import mk, EmpiricalTestCase
+from OpenSSL import crypto
 
+from chevah.keycert.exceptions import KeyCertException
+from chevah.keycert.ssl import (
+    generate_and_store_csr,
+    generate_csr,
+    generate_csr_parser,
+    generate_ssl_self_signed_certificate,
+    )
 from chevah.keycert.tests.helpers import CommandLineMixin
 
 
-class Test_generate_ssl_key_certificate_signing_request_subparser(
-        EmpiricalTestCase, CommandLineMixin):
+class CommandLineTestBase(EmpiricalTestCase, CommandLineMixin):
     """
-    Unit tests for generate_ssl_key_certificate_signing_request_subparser.
+    Share code for testing methods which read SSL command line input.
     """
 
     def setUp(self):
-        super(Test_generate_ssh_key_subparser, self).setUp()
+        super(CommandLineTestBase, self).setUp()
+        self.parser = ArgumentParser(prog='test-command')
+        subparser = self.parser.add_subparsers(
+            help='Available sub-commands', dest='sub_command')
+        self.command_name = 'gen-csr'
+        generate_csr_parser(subparser, self.command_name)
+
+
+class Test_generate_ssl_self_signed_certificate(EmpiricalTestCase):
+    """
+    Unit tests for generate_ssl_self_signed_certificate.
+    """
+
+    def test_generate(self):
+        """
+        Will generate the key and self signed certificate for current
+        hostname.
+        """
+        cert_pem, key_pem = generate_ssl_self_signed_certificate()
+
+        key = crypto.load_privatekey(crypto.FILETYPE_PEM, key_pem)
+        cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_pem)
+        self.assertEqual(1024, key.bits())
+        self.assertEqual(crypto.TYPE_RSA, key.type())
+        subject = cert.get_subject()
+        self.assertEqual(u'UN', subject.C)
+        issuer = cert.get_issuer()
+        self.assertEqual(cert.subject_name_hash(), issuer.hash())
+
+
+class Test_generate_csr_parser(
+        EmpiricalTestCase, CommandLineMixin):
+    """
+    Unit tests for generate_csr_parser.
+    """
+
+    def setUp(self):
+        super(Test_generate_csr_parser, self).setUp()
         self.parser = ArgumentParser(prog='test-command')
         self.subparser = self.parser.add_subparsers(
             help='Available sub-commands', dest='sub_command')
@@ -31,18 +70,21 @@ class Test_generate_ssl_key_certificate_signing_request_subparser(
         """
         It can not be called without at least the common-name argument
         """
-        generate_ssl_key_certificate_signing_request_subparser(
-            self.subparser, 'key-gen')
+        generate_csr_parser(self.subparser, 'key-gen')
 
-        options = self.parseArguments(['key-gen'])
+        code, error = self.parseArgumentsFailure(['key-gen'])
 
+        self.assertStartsWith('usage: test-command key-gen [-h]', error)
+        self.assertEndsWith(
+            '\ntest-command key-gen: '
+            'error: argument --common-name is required\n',
+            error)
 
     def test_default(self):
         """
         It can be initiaized with only a subparser and sub-command name.
         """
-        generate_ssl_key_certificate_signing_request_subparser(
-            self.subparser, 'key-gen')
+        generate_csr_parser(self.subparser, 'key-gen')
 
         options = self.parseArguments([
             'key-gen',
@@ -51,47 +93,303 @@ class Test_generate_ssl_key_certificate_signing_request_subparser(
 
         self.assertNamespaceEqual({
             'sub_command': 'key-gen',
-            'key_file': None,
+            'key_file': 'server.key',
             'key_size': 2048,
             'key_type': 'rsa',
+            'key_password': None,
+            'common_name': 'domain.com',
+            'alternative_name': None,
+            'email': None,
+            'organization': None,
+            'organization_unit': None,
+            'locality': None,
+            'state': None,
+            'country': None,
             }, options)
 
     def test_value(self):
         """
         Options are parsed form command line.
         """
-        generate_ssl_key_certificate_signing_request_subparser(
-            self.subparser, 'key-gen')
+        generate_csr_parser(self.subparser, 'key-gen')
 
         options = self.parseArguments([
             'key-gen',
-            '--key-file=id_dsa',
+            '--common-name', 'sub.domain.com',
+            '--key-file=my_server.pem',
             '--key-size', '1024',
             '--key-type', 'dsa',
+            '--key-password', u'valu\u20ac',
+            '--alternative-name', 'DNS:www.domain.com,IP:127.0.0.1',
+            '--email', 'admin@domain.com',
+            '--organization', 'OU Name',
+            '--organization-unit=OU Unit',
+            '--locality=somewhere',
+            '--state=without',
+            '--country=GB',
             ])
 
         self.assertNamespaceEqual({
             'sub_command': 'key-gen',
-            'key_file': 'id_dsa',
+            'key_file': 'my_server.pem',
             'key_size': 1024,
             'key_type': 'dsa',
+            'key_password': u'valu\u20ac',
+            'common_name': 'sub.domain.com',
+            'alternative_name': 'DNS:www.domain.com,IP:127.0.0.1',
+            'email': 'admin@domain.com',
+            'organization': 'OU Name',
+            'organization_unit': 'OU Unit',
+            'locality': 'somewhere',
+            'state': 'without',
+            'country': 'GB',
             }, options)
 
     def test_default_overwrite(self):
         """
         You can change default values.
         """
-        generate_ssl_key_certificate_signing_request_subparser(
+        generate_csr_parser(
             self.subparser, 'key-gen',
             default_key_size=1024,
             default_key_type='dsa',
             )
 
-        options = self.parseArguments(['key-gen'])
+        options = self.parseArguments([
+            'key-gen',
+            '--common-name', 'domain.com',
+            ])
 
         self.assertNamespaceEqual({
             'sub_command': 'key-gen',
-            'key_file': None,
+            'key_file': 'server.key',
             'key_size': 1024,
             'key_type': 'dsa',
+            'key_password': None,
+            'common_name': 'domain.com',
+            'alternative_name': None,
+            'email': None,
+            'organization': None,
+            'organization_unit': None,
+            'locality': None,
+            'state': None,
+            'country': None,
             }, options)
+
+
+class Test_generate_csr(CommandLineTestBase):
+    """
+    Unit tests for generate_csr.
+    """
+
+    def test_unknown_key(self):
+        """
+        Raise an exception when requested to generate a key with unknown type.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            '--common-name=domain.com',
+            '--key-type=no-such-type',
+            ])
+
+        with self.assertRaises(KeyCertException) as context:
+            generate_csr(options)
+
+        self.assertEqual('Unknown key type.', context.exception.message)
+
+    def test_bad_size(self):
+        """
+        Raise an exception when failing to generate the key.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            '--common-name=domain.com',
+            '--key-type=rsa',
+            '--key-size=12',
+            ])
+
+        with self.assertRaises(KeyCertException) as context:
+            generate_csr(options)
+
+        self.assertEqual('key size too small', context.exception.message)
+
+    def test_bad_county_long(self):
+        """
+        Raise an exception when country code is not correct.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            '--common-name=domain.com',
+            '--country=USA',
+            ])
+
+        with self.assertRaises(KeyCertException) as context:
+            generate_csr(options)
+
+        self.assertEqual('string too long', context.exception.message)
+
+    def test_bad_county_short(self):
+        """
+        Raise an exception when country code is not correct.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            '--common-name=domain.com',
+            '--country=A',
+            ])
+
+        with self.assertRaises(KeyCertException) as context:
+            generate_csr(options)
+
+        self.assertEqual('string too short', context.exception.message)
+
+    def test_default_gen(self):
+        """
+        By default it will serialized the key without password and generate
+        the csr without alternative name and just the common name.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            '--common-name=domain.com',
+            ])
+
+        result = generate_csr(options)
+
+        # OpenSSL.crypto.PKey has no equality so we need to compare the
+        # serialization.
+        self.assertEqual(2048L, result['key'].bits())
+        self.assertEqual(crypto.TYPE_RSA, result['key'].type())
+        key = crypto.dump_privatekey(crypto.FILETYPE_PEM, result['key'])
+        self.assertEqual(key, result['key_pem'])
+        # For CSR we can not get extensions so we only check the subject.
+        csr = crypto.dump_certificate_request(
+            crypto.FILETYPE_PEM, result['csr'])
+        self.assertEqual(csr, result['csr_pem'])
+        subject = result['csr'].get_subject()
+        self.assertEqual(u'domain.com', subject.commonName)
+        self.assertIsNone(subject.emailAddress)
+        self.assertIsNone(subject.organizationName)
+        self.assertIsNone(subject.organizationalUnitName)
+        self.assertIsNone(subject.localityName)
+        self.assertIsNone(subject.stateOrProvinceName)
+        self.assertIsNone(subject.countryName)
+
+    def test_gen_unicode(self):
+        """
+        Domains are encoded using IDNA and names using unicode.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            u'--common-name=domain-\u20acuro.com',
+            u'--key-size=512',
+            u'--key-type=rsa',
+            u'--alternative-name=DNS:www.domain-\u20acuro.com,IP:127.0.0.1',
+            u'--email=name@domain-\u20acuro.com',
+            u'--organization=OU Nam\u20acuro',
+            u'--organization-unit=OU Unit\u20acuro',
+            u'--locality=Som\u20acwhere',
+            u'--state=Stat\u20ac',
+            u'--country=GB',
+            ])
+
+        result = generate_csr(options)
+
+        csr = crypto.dump_certificate_request(
+            crypto.FILETYPE_PEM, result['csr'])
+        self.assertEqual(csr, result['csr_pem'])
+        subject = result['csr'].get_subject()
+        self.assertEqual(u'xn--domain-uro-x77e.com', subject.commonName)
+        self.assertEqual(
+            u'name@xn--domain-uro-x77e.com', subject.emailAddress)
+        self.assertEqual(u'OU Nam\u20acuro', subject.organizationName)
+        self.assertEqual(u'OU Unit\u20acuro', subject.organizationalUnitName)
+        self.assertEqual(u'Som\u20acwhere', subject.localityName)
+        self.assertEqual(u'Stat\u20ac', subject.stateOrProvinceName)
+        self.assertEqual(u'GB', subject.countryName)
+
+    def test_encrypted_key(self):
+        """
+        When asked it serialized the key with a password.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            u'--common-name=domain.com',
+            u'--key-size=512',
+            u'--key-password=\u20acuro',
+            ])
+
+        result = generate_csr(options)
+
+        # We decrypt the key and compare the unencrypted serialization.
+        key = crypto.load_privatekey(
+            crypto.FILETYPE_PEM,
+            result['key_pem'],
+            u'\u20acuro'.encode('utf-8'))
+        self.assertEqual(
+            crypto.dump_privatekey(crypto.FILETYPE_PEM, key),
+            crypto.dump_privatekey(crypto.FILETYPE_PEM, result['key']),
+            )
+
+    def test_dsa_key(self):
+        """
+        It can also generate key as DSA.
+        """
+        options = self.parseArguments([
+            self.command_name,
+            u'--common-name=domain.com',
+            u'--key-size=512',
+            u'--key-type=dsa',
+            ])
+
+        result = generate_csr(options)
+
+        self.assertEqual(crypto.TYPE_DSA, result['key'].type())
+
+
+class Test_generate_and_store_csr(CommandLineTestBase):
+    """
+    Unit tests for generate_and_store_csr.
+    """
+
+    def test_key_exists(self):
+        """
+        Raise an exception when server key already exists.
+        """
+        self.test_segments = mk.fs.createFileInTemp()
+        path = mk.fs.getRealPathFromSegments(self.test_segments)
+        options = self.parseArguments([
+            self.command_name,
+            '--common-name=domain.com',
+            '--key-file', path,
+            ])
+
+        with self.assertRaises(KeyCertException) as context:
+            generate_and_store_csr(options)
+
+        self.assertEqual('Key file already exists.', context.exception.message)
+
+    def test_key_and_csr(self):
+        """
+        Will write the key an csr on local filesystem.
+        """
+        key_path, self.test_segments = mk.fs.makePathInTemp()
+        csr_segments = self.test_segments[:]
+        csr_segments[-1] = u'%s.csr' % csr_segments[-1]
+        self.addCleanup(mk.fs.deleteFile, csr_segments)
+
+        options = self.parseArguments([
+            self.command_name,
+            '--common-name=domain.com',
+            '--key-file', key_path,
+            '--key-size=512',
+            ])
+
+        generate_and_store_csr(options)
+
+        key_content = mk.fs.getFileContent(self.test_segments)
+        key = crypto.load_privatekey(
+            crypto.FILETYPE_PEM, key_content)
+        self.assertEqual(512, key.bits())
+        csr_content = mk.fs.getFileContent(csr_segments)
+        csr = crypto.load_certificate_request(crypto.FILETYPE_PEM, csr_content)
+        self.assertEqual(u'domain.com', csr.get_subject().CN)

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2015 Adi Roiban.
+# See LICENSE for details.
+"""
+Test for SSL keys/cert management.
+"""
+from argparse import ArgumentParser, Namespace
+from hashlib import sha1
+from StringIO import StringIO
+import base64
+import sys
+import textwrap
+
+from chevah.empirical import mk, EmpiricalTestCase
+
+from chevah.keycert.tests.helpers import CommandLineMixin
+
+
+class Test_generate_ssl_key_certificate_signing_request_subparser(
+        EmpiricalTestCase, CommandLineMixin):
+    """
+    Unit tests for generate_ssl_key_certificate_signing_request_subparser.
+    """
+
+    def setUp(self):
+        super(Test_generate_ssh_key_subparser, self).setUp()
+        self.parser = ArgumentParser(prog='test-command')
+        self.subparser = self.parser.add_subparsers(
+            help='Available sub-commands', dest='sub_command')
+
+    def test_common_name_required(self):
+        """
+        It can not be called without at least the common-name argument
+        """
+        generate_ssl_key_certificate_signing_request_subparser(
+            self.subparser, 'key-gen')
+
+        options = self.parseArguments(['key-gen'])
+
+
+    def test_default(self):
+        """
+        It can be initiaized with only a subparser and sub-command name.
+        """
+        generate_ssl_key_certificate_signing_request_subparser(
+            self.subparser, 'key-gen')
+
+        options = self.parseArguments([
+            'key-gen',
+            '--common-name', 'domain.com',
+            ])
+
+        self.assertNamespaceEqual({
+            'sub_command': 'key-gen',
+            'key_file': None,
+            'key_size': 2048,
+            'key_type': 'rsa',
+            }, options)
+
+    def test_value(self):
+        """
+        Options are parsed form command line.
+        """
+        generate_ssl_key_certificate_signing_request_subparser(
+            self.subparser, 'key-gen')
+
+        options = self.parseArguments([
+            'key-gen',
+            '--key-file=id_dsa',
+            '--key-size', '1024',
+            '--key-type', 'dsa',
+            ])
+
+        self.assertNamespaceEqual({
+            'sub_command': 'key-gen',
+            'key_file': 'id_dsa',
+            'key_size': 1024,
+            'key_type': 'dsa',
+            }, options)
+
+    def test_default_overwrite(self):
+        """
+        You can change default values.
+        """
+        generate_ssl_key_certificate_signing_request_subparser(
+            self.subparser, 'key-gen',
+            default_key_size=1024,
+            default_key_type='dsa',
+            )
+
+        options = self.parseArguments(['key-gen'])
+
+        self.assertNamespaceEqual({
+            'sub_command': 'key-gen',
+            'key_file': None,
+            'key_size': 1024,
+            'key_type': 'dsa',
+            }, options)

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -1,6 +1,7 @@
 """
 Demo command line for chevah-keycert.
 """
+from __future__ import print_function
 # Fix namespaced package import.
 import chevah
 import os
@@ -8,19 +9,33 @@ chevah.__path__.insert(0, os.path.join(os.getcwd(), 'chevah'))
 
 import argparse
 import sys
+from chevah.keycert.exceptions import KeyCertException
 from chevah.keycert.ssh import (
     generate_ssh_key,
     generate_ssh_key_subparser,
+    )
+from chevah.keycert.ssl import (
+    generate_ssl_key_certificate_signing_request,
+    generate_ssl_key_certificate_signing_request_subparser,
     )
 
 parser = argparse.ArgumentParser(prog='PROG', prefix_chars='-+')
 subparser = parser.add_subparsers(
             help='Available sub-commands', dest='sub_command')
 
-generate_ssh_key_subparser(subparser, 'gen-ssh-key')
+sub = generate_ssh_key_subparser(subparser, 'ssh-gen-key')
+sub.set_defaults(handler=generate_ssh_key)
+
+sub = generate_ssl_key_certificate_signing_request_subparser(
+    subparser, 'ssl-gen-key')
+sub.set_defaults(handler=generate_ssl_key_certificate_signing_request)
+
 
 options = parser.parse_args()
-if options.sub_command == 'gen-ssh-key':
-    exit, message, _ = generate_ssh_key(options)
-    sys.stdout.write(message)
-    sys.exit(exit)
+
+try:
+    result = options.handler(options)
+    print(result)
+except KeyCertException as error:
+    print(error)
+    sys.exit(1)

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -15,8 +15,8 @@ from chevah.keycert.ssh import (
     generate_ssh_key_subparser,
     )
 from chevah.keycert.ssl import (
-    generate_ssl_key_certificate_signing_request,
-    generate_ssl_key_certificate_signing_request_subparser,
+    generate_csr_parser,
+    generate_and_store_csr,
     )
 
 parser = argparse.ArgumentParser(prog='PROG', prefix_chars='-+')
@@ -26,16 +26,14 @@ subparser = parser.add_subparsers(
 sub = generate_ssh_key_subparser(subparser, 'ssh-gen-key')
 sub.set_defaults(handler=generate_ssh_key)
 
-sub = generate_ssl_key_certificate_signing_request_subparser(
-    subparser, 'ssl-gen-key')
-sub.set_defaults(handler=generate_ssl_key_certificate_signing_request)
-
+sub = generate_csr_parser(subparser, 'ssl-gen-key')
+sub.set_defaults(handler=generate_and_store_csr)
 
 options = parser.parse_args()
 
 try:
-    result = options.handler(options)
-    print(result)
+    options.handler(options)
+    print('command succeed')
 except KeyCertException as error:
     print(error)
     sys.exit(1)

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Relese notes for Chevah KeyCert
 ###############################
 
 
+1.3.0 - 07/04/2015
+==================
+
+* Add support to generate a SSL key and associated CSR.
+
+
 1.2.0 - 03/04/2015
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ class NoseTestCommand(TestCommand):
             '--cover-package=' + module,
             '--cover-erase',
             '--cover-test',
+            '--with-timer',
             module.replace('.', '/'),
             ])
 
@@ -100,6 +101,12 @@ setup(
     keywords='twisted ssh ssl tls pki ca',
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+
+    entry_points={
+        'nose.plugins.0.10': [
+            'timer = chevah.empirical.nose_test_timer:TestTimer'
+            ]
+        },
 
     install_requires=[
         'pyopenssl ==0.13',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.2.0'
+VERSION = '1.3.0'
 
 
 class NoseTestCommand(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -109,9 +109,9 @@ setup(
         },
 
     install_requires=[
-        'pyopenssl ==0.13',
-        'pyCrypto ==2.6.1',
-        'pyasn1 ==0.1.7',
+        'pyopenssl >=0.13',
+        'pyCrypto >=2.6',
+        'pyasn1 >=0.1.7',
         'chevah-compat ==0.27.1',
         ],
 


### PR DESCRIPTION
Problem
======

We want to create CSR + key from command line but also from Python API

Changes
=======

Created 3 new methods. one to generate the commnad line options, another one to to generate the key/csr and another one to take care of writing to disk.


As a drive by I have updated the test runner to print speed reports and wrote a test for self signed certificate so that we have 100% coverage for ssl module.

How to test
========

reviewers: @alibotean 

check that changes make sense

Use the demo tool to generate a csr