### PR TITLE
Force a specific filesystem encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ clean:
 test:
 	@$(BASE_PATH)/python setup.py test -q
 	@echo "See HTML coverate in build/cover"
-	@coverage html -d build/cover/
+	@$(BASE_PATH)/coverage html -d build/cover/

--- a/chevah/keycert/__init__.py
+++ b/chevah/keycert/__init__.py
@@ -8,6 +8,8 @@ import sys
 def _path(path, encoding):
     if os.name != 'posix' or sys.platform.startswith('darwin'):
         # On Windows and OSX we always use unicode.
+        # We don't run yet tests on Windows and OSX.
+        # pragma: no cover
         return path
 
     return path.encode('utf-8')

--- a/chevah/keycert/__init__.py
+++ b/chevah/keycert/__init__.py
@@ -1,0 +1,13 @@
+"""
+SSL and SSH key management.
+"""
+import os
+import sys
+
+
+def _path(path, encoding):
+    if os.name != 'posix' or sys.platform.startswith('darwin'):
+        # On Windows and OSX we always use unicode.
+        return path
+
+    return path.encode('utf-8')

--- a/chevah/keycert/__init__.py
+++ b/chevah/keycert/__init__.py
@@ -9,7 +9,6 @@ def _path(path, encoding):
     if os.name != 'posix' or sys.platform.startswith('darwin'):
         # On Windows and OSX we always use unicode.
         # We don't run yet tests on Windows and OSX.
-        # pragma: no cover
-        return path
+        return path  # pragma: no cover
 
     return path.encode('utf-8')

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -8,6 +8,7 @@ import os
 
 from OpenSSL import crypto
 
+from chevah.keycert import _path
 from chevah.keycert.exceptions import KeyCertException
 
 _DEFAULT_SSL_KEY_CYPHER = b'aes-256-cbc'
@@ -217,7 +218,7 @@ def _generate_csr(options):
         }
 
 
-def generate_and_store_csr(options):
+def generate_and_store_csr(options, encoding='utf-8'):
     """
     Generate a key/csr and try to store it on disk.
 
@@ -226,13 +227,13 @@ def generate_and_store_csr(options):
     name, _ = os.path.splitext(options.key_file)
     csr_name = u'%s.csr' % name
 
-    if os.path.exists(options.key_file):
+    if os.path.exists(_path(options.key_file, encoding)):
         raise KeyCertException('Key file already exists.')
 
     result = generate_csr(options)
 
-    with open(options.key_file, 'wb') as store_file:
+    with open(_path(options.key_file, encoding), 'wb') as store_file:
         store_file.write(result['key_pem'])
 
-    with open(csr_name, 'wb') as store_file:
+    with open(_path(csr_name, encoding), 'wb') as store_file:
         store_file.write(result['csr_pem'])

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Relese notes for Chevah KeyCert
 ###############################
 
 
+1.3.1 - 08/04/2015
+==================
+
+* On Unix/Linux ignore sys.getfilesystemencoding() and force a specific
+  encoding. UTF-8 by default.
+
+
 1.3.0 - 07/04/2015
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.3.0'
+VERSION = '1.3.1'
 
 
 class NoseTestCommand(TestCommand):
@@ -112,7 +112,7 @@ setup(
         'pyopenssl >=0.13',
         'pyCrypto >=2.6',
         'pyasn1 >=0.1.7',
-        'chevah-compat ==0.27.1',
+        'chevah-compat >=0.27.1',
         ],
 
     extras_require={


### PR DESCRIPTION
Problem
======

On Unix/Linux sys.getdefaultfilesystem is smart ... but it get into our way.

Changes
=======

Update filesystem code to use utf-8 by default.

How to test
========

reviewers: @alibotean 

check that changes make sense.

I am already using this code on a server branch.

Thanks!