### PR TITLE
Remove DSA key type.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,3 +31,5 @@ is Linux only::
     make test_remote
     # Trigger a builder
     make test_remote TARGET=keycert-win-2008
+    # Trigger a builder with running the clean step
+    make test_remote_with_clean TARGET=keycert-win-2008

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,3 +21,11 @@ To get HTML coverage report use::
 Default virtual environment is created in build/venv.
 
 Use nosetests for TDD.
+
+Linux, OS X and Windows tests executed on private buildbot server as Travis CI
+is Linux only::
+
+    # See available builders
+    make test_remote
+    # Trigger a builder
+    make test_remote TARGET=keycert-win-2008

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,6 +25,8 @@ Use nosetests for TDD.
 Linux, OS X and Windows tests executed on private buildbot server as Travis CI
 is Linux only::
 
+    # Install dev dependencies
+    make dev_deps
     # See available builders
     make test_remote
     # Trigger a builder

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 EXTRA_PYPI_INDEX='http://chevah.com/pypi/simple'
 
 ifeq "$(MSYSTEM)" "MINGW32"
-       BASE_PATH='build/venv/lib/Scripts'
+       BASE_PATH='build/venv/Scripts'
 else
        BASE_PATH='build/venv/bin'
 endif
@@ -68,3 +68,6 @@ ifeq "$(TARGET)" ""
 else
 	$(BUILDBOT_TRY) -b $(TARGET)
 endif
+
+test_remote_with_clean:
+	$(BUILDBOT_TRY) -b $(TARGET) --properties=force_clean=yes

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@
 # Makefile for Chevah KeyCert project.
 #
 EXTRA_PYPI_INDEX='http://chevah.com/pypi/simple'
-UNAME=`uname`
-ifeq "$(UNAME)" "mingw"
-       BASE_PATH='build/venv/Scripts/'
+
+ifeq "$(MSYSTEM)" "MINGW32"
+       BASE_PATH='build/venv/lib/Scripts'
 else
-       BASE_PATH='build/venv/bin/'
+       BASE_PATH='build/venv/bin'
 endif
+
+BUILDBOT_TRY=$(BASE_PATH)/buildbot try \
+		--connect=pb --username=chevah_buildbot --passwd=chevah_password \
+		--master=build.chevah.com:10087 --vc=git
+
 
 all: test
 	
@@ -46,9 +51,20 @@ ci_env:
 
 
 ci_test:
-	ifeq "$(TEST_TYPE)" "os-independent"
-	    @$(BASE_PATH)/pyflakes chevah
-	    @$(BASE_PATH)/pep8 chevah
-	else
-	    @$(BASE_PATH)/nosetests
-	endif
+ifeq "$(TEST_TYPE)" "os-independent"
+	@$(BASE_PATH)/pyflakes chevah
+	@$(BASE_PATH)/pep8 chevah
+else
+	@$(BASE_PATH)/nosetests
+endif
+
+
+dev_deps:
+	@$(BASE_PATH)/pip install buildbot
+
+test_remote:
+ifeq "$(TARGET)" ""
+	$(BUILDBOT_TRY) --get-builder-names | grep keycert
+else
+	$(BUILDBOT_TRY) -b $(TARGET)
+endif

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,15 @@ endif
 all: test
 	
 
-env:
+local_env:
 	@if [ ! -d "build/venv" ]; then virtualenv build/venv; fi
 	@$(BASE_PATH)/pip install -U pip
 
 
-deps: env
+deps: local_env deps_base
+
+
+deps_base:
 	@$(BASE_PATH)/pip install \
 		--extra-index-url ${EXTRA_PYPI_INDEX}\
 		--trusted-host chevah.com \
@@ -32,3 +35,20 @@ test:
 	@$(BASE_PATH)/python setup.py test -q
 	@echo "See HTML coverate in build/cover"
 	@$(BASE_PATH)/coverage html -d build/cover/
+
+
+ci_deps: ci_env deps_base
+
+
+ci_env:
+	@mkdir -p build
+	./paver.sh distributable_python build/venv
+
+
+ci_test:
+	ifeq "$(TEST_TYPE)" "os-independent"
+	    @$(BASE_PATH)/pyflakes chevah
+	    @$(BASE_PATH)/pep8 chevah
+	else
+	    @$(BASE_PATH)/nosetests
+	endif

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -56,7 +56,7 @@ class KeyCertException(Exception):
     """
 
 
-def generate_ssh_key_subparser(
+def generate_ssh_key_parser(
         subparsers, name, default_key_size=2048, default_key_type='rsa'):
     """
     Create an argparse sub-command with `name` attached to `subparsers`.

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -23,6 +23,7 @@ from pyasn1.type import univ
 
 from chevah.compat import local_filesystem
 
+from chevah.keycert import _path
 from chevah.keycert import common, sexpy
 
 
@@ -275,12 +276,12 @@ class Key(object):
         return '\n'.join(lines)
 
     @classmethod
-    def fromFile(cls, filename, type=None, passphrase=None):
+    def fromFile(cls, filename, type=None, passphrase=None, encoding='utf-8'):
         """
         Return a Key object corresponding to the data in filename.  type
         and passphrase function as they do in fromString.
         """
-        with open(filename, 'rb') as file:
+        with open(_path(filename, encoding), 'rb') as file:
             return cls.fromString(file.read(), type, passphrase)
 
     @classmethod

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -151,7 +151,7 @@ def _generate_csr(options):
     elif key_type == 'rsa':
         key_type = crypto.TYPE_RSA
     else:
-        raise KeyCertException('Unknown key type.')
+        raise KeyCertException(u'Unknown key type: %s' % (key_type,))
 
     csr = crypto.X509Req()
     subject = csr.get_subject()

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -43,8 +43,7 @@ def generate_ssl_self_signed_certificate():
     return (certificate_pem, key_pem)
 
 
-def generate_csr_parser(
-        subparsers, name, default_key_size=2048, default_key_type='rsa'):
+def generate_csr_parser(subparsers, name, default_key_size=2048):
     """
     Create an argparse sub-command for generating CSR options with
     `name` attached to `subparsers`.
@@ -73,13 +72,9 @@ def generate_csr_parser(
     sub_command.add_argument(
         '--key-size',
         type=int, metavar="SIZE", default=default_key_size,
-        help='Generate a RSA or DSA key of size SIZE. Default %(default)s',
+        help='Size of the generate RSA private key. Default %(default)s',
         )
-    sub_command.add_argument(
-        '--key-type',
-        metavar="[rsa|dsa]", default=default_key_type,
-        help='Generate a DSA or RSA key. Default %(default)s.',
-        )
+
     sub_command.add_argument(
         '--key-password',
         metavar="PASSPHRASE",
@@ -106,13 +101,13 @@ def generate_csr_parser(
         )
     sub_command.add_argument(
         '--locality',
-        help='Full name location associated with the generated CSR.',
+        help='Full name of the locality associated with the generated CSR.',
         )
     sub_command.add_argument(
         '--state',
         help=(
-            'Full name of the state/county/region associated with the '
-            'generated CSR.'),
+            'Full name of the state/county/region/province associated with the'
+            ' generated CSR.'),
         )
     sub_command.add_argument(
         '--country',
@@ -144,14 +139,7 @@ def _generate_csr(options):
     """
     Helper to catch all crypto errors and reduce indentation.
     """
-    key_type = options.key_type.lower()
-
-    if key_type == 'dsa':
-        key_type = crypto.TYPE_DSA
-    elif key_type == 'rsa':
-        key_type = crypto.TYPE_RSA
-    else:
-        raise KeyCertException(u'Unknown key type: %s' % (key_type,))
+    key_type = crypto.TYPE_RSA
 
     csr = crypto.X509Req()
     subject = csr.get_subject()

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -22,7 +22,7 @@ from chevah.keycert.ssh import (
     EncryptedKeyError,
     Key,
     generate_ssh_key,
-    generate_ssh_key_subparser,
+    generate_ssh_key_parser,
     )
 from chevah.keycert.tests import keydata
 from chevah.keycert.tests.helpers import CommandLineMixin
@@ -1711,13 +1711,13 @@ attr u:
 \t04>""")
 
 
-class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
+class Test_generate_ssh_key_parser(EmpiricalTestCase, CommandLineMixin):
     """
-    Unit tests for generate_ssh_key_subparser.
+    Unit tests for generate_ssh_key_parser.
     """
 
     def setUp(self):
-        super(Test_generate_ssh_key_subparser, self).setUp()
+        super(Test_generate_ssh_key_parser, self).setUp()
         self.parser = ArgumentParser(prog='test-command')
         self.subparser = self.parser.add_subparsers(
             help='Available sub-commands', dest='sub_command')
@@ -1726,7 +1726,7 @@ class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
         """
         It only need a subparser and sub-command name.
         """
-        generate_ssh_key_subparser(self.subparser, 'key-gen')
+        generate_ssh_key_parser(self.subparser, 'key-gen')
 
         options = self.parseArguments(['key-gen'])
 
@@ -1743,7 +1743,7 @@ class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
         """
         Options are parsed from the command line.
         """
-        generate_ssh_key_subparser(self.subparser, 'key-gen')
+        generate_ssh_key_parser(self.subparser, 'key-gen')
 
         options = self.parseArguments([
             'key-gen',
@@ -1767,7 +1767,7 @@ class Test_generate_ssh_key_subparser(EmpiricalTestCase, CommandLineMixin):
         """
         You can change default values.
         """
-        generate_ssh_key_subparser(
+        generate_ssh_key_parser(
             self.subparser, 'key-gen',
             default_key_size=1024,
             default_key_type='dsa',
@@ -1796,7 +1796,7 @@ class Testgenerate_ssh_key(EmpiricalTestCase, CommandLineMixin):
         self.sub_command_name = 'gen-ssh-key'
         subparser = self.parser.add_subparsers(
             help='Available sub-commands', dest='sub_command')
-        generate_ssh_key_subparser(subparser, self.sub_command_name)
+        generate_ssh_key_parser(subparser, self.sub_command_name)
 
     def test_generate_ssh_key_custom_values(self):
         """

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -95,7 +95,6 @@ class Test_generate_csr_parser(
             'sub_command': 'key-gen',
             'key_file': 'server.key',
             'key_size': 2048,
-            'key_type': 'rsa',
             'key_password': None,
             'common_name': 'domain.com',
             'alternative_name': None,
@@ -118,7 +117,6 @@ class Test_generate_csr_parser(
             '--common-name', 'sub.domain.com',
             '--key-file=my_server.pem',
             '--key-size', '1024',
-            '--key-type', 'dsa',
             '--key-password', u'valu\u20ac',
             '--alternative-name', 'DNS:www.domain.com,IP:127.0.0.1',
             '--email', 'admin@domain.com',
@@ -133,7 +131,6 @@ class Test_generate_csr_parser(
             'sub_command': 'key-gen',
             'key_file': 'my_server.pem',
             'key_size': 1024,
-            'key_type': 'dsa',
             'key_password': u'valu\u20ac',
             'common_name': 'sub.domain.com',
             'alternative_name': 'DNS:www.domain.com,IP:127.0.0.1',
@@ -152,7 +149,6 @@ class Test_generate_csr_parser(
         generate_csr_parser(
             self.subparser, 'key-gen',
             default_key_size=1024,
-            default_key_type='dsa',
             )
 
         options = self.parseArguments([
@@ -164,7 +160,6 @@ class Test_generate_csr_parser(
             'sub_command': 'key-gen',
             'key_file': 'server.key',
             'key_size': 1024,
-            'key_type': 'dsa',
             'key_password': None,
             'common_name': 'domain.com',
             'alternative_name': None,
@@ -182,22 +177,6 @@ class Test_generate_csr(CommandLineTestBase):
     Unit tests for generate_csr.
     """
 
-    def test_unknown_key(self):
-        """
-        Raise an exception when requested to generate a key with unknown type.
-        """
-        options = self.parseArguments([
-            self.command_name,
-            '--common-name=domain.com',
-            '--key-type=no-such-type',
-            ])
-
-        with self.assertRaises(KeyCertException) as context:
-            generate_csr(options)
-
-        self.assertEqual(
-            u'Unknown key type: no-such-type', context.exception.message)
-
     def test_bad_size(self):
         """
         Raise an exception when failing to generate the key.
@@ -205,7 +184,6 @@ class Test_generate_csr(CommandLineTestBase):
         options = self.parseArguments([
             self.command_name,
             '--common-name=domain.com',
-            '--key-type=rsa',
             '--key-size=12',
             ])
 
@@ -283,7 +261,6 @@ class Test_generate_csr(CommandLineTestBase):
             self.command_name,
             u'--common-name=domain-\u20acuro.com',
             u'--key-size=512',
-            u'--key-type=rsa',
             u'--alternative-name=DNS:www.domain-\u20acuro.com,IP:127.0.0.1',
             u'--email=name@domain-\u20acuro.com',
             u'--organization=OU Nam\u20acuro',
@@ -330,21 +307,6 @@ class Test_generate_csr(CommandLineTestBase):
             crypto.dump_privatekey(crypto.FILETYPE_PEM, key),
             crypto.dump_privatekey(crypto.FILETYPE_PEM, result['key']),
             )
-
-    def test_dsa_key(self):
-        """
-        It can also generate key as DSA.
-        """
-        options = self.parseArguments([
-            self.command_name,
-            u'--common-name=domain.com',
-            u'--key-size=512',
-            u'--key-type=dsa',
-            ])
-
-        result = generate_csr(options)
-
-        self.assertEqual(crypto.TYPE_DSA, result['key'].type())
 
 
 class Test_generate_and_store_csr(CommandLineTestBase):

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -195,7 +195,8 @@ class Test_generate_csr(CommandLineTestBase):
         with self.assertRaises(KeyCertException) as context:
             generate_csr(options)
 
-        self.assertEqual('Unknown key type.', context.exception.message)
+        self.assertEqual(
+            u'Unknown key type: no-such-type', context.exception.message)
 
     def test_bad_size(self):
         """

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -12,7 +12,7 @@ import sys
 from chevah.keycert.exceptions import KeyCertException
 from chevah.keycert.ssh import (
     generate_ssh_key,
-    generate_ssh_key_subparser,
+    generate_ssh_key_parser,
     )
 from chevah.keycert.ssl import (
     generate_csr_parser,
@@ -23,7 +23,7 @@ parser = argparse.ArgumentParser(prog='PROG', prefix_chars='-+')
 subparser = parser.add_subparsers(
             help='Available sub-commands', dest='sub_command')
 
-sub = generate_ssh_key_subparser(subparser, 'ssh-gen-key')
+sub = generate_ssh_key_parser(subparser, 'ssh-gen-key')
 sub.set_defaults(handler=generate_ssh_key)
 
 sub = generate_csr_parser(subparser, 'ssl-gen-key')

--- a/paver.sh
+++ b/paver.sh
@@ -337,7 +337,7 @@ distributable_python() {
     mv ${PYTHON_VERSION}-${OS}-${ARCH} $destination
 
     pushd $destination
-        execute wget https://bootstrap.pypa.io/get-pip.py
+        execute wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
         execute $python_bin get-pip.py
     popd
 }

--- a/paver.sh
+++ b/paver.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+# Copyright (c) 2010-2013 Adi Roiban.
+# See LICENSE for details.
+#
+# Helper script for bootstraping the build system on Unix/Msys.
+# It will write the default values into 'DEFAULT_VALUES' file.
+#
+# To use this script you will need to publish binary archive files for the
+# following components:
+#
+# * Python main distribution
+# * pip
+# * setuptools
+#
+# It will delegate the argument to the paver script, with the exception of
+# these commands:
+# * clean - remove everything, except cache
+# * detect_os - create DEFAULT_VALUES and exit
+# * get_python - download Python distribution in cache
+# * get_agent - download Rexx/Putty distribution in cache
+#
+
+# Script initialization.
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Initialize default value.
+COMMAND=${1-''}
+DEBUG=${DEBUG-0}
+
+# Set default locale.
+# We use C (alias for POSIX) for having a basic default value and
+# to make sure we explictly convert all unicode values.
+export LANG='C'
+export LANGUAGE='C'
+export LC_ALL='C'
+export LC_CTYPE='C'
+export LC_COLLATE='C'
+export LC_MESSAGES='C'
+export PATH=$PATH:'/sbin:/usr/sbin:/usr/local/bin'
+
+#
+# Global variables.
+#
+# Used to return non-scalar value from functions.
+RESULT=''
+WAS_PYTHON_JUST_INSTALLED=0
+DIST_FOLDER='dist'
+
+# Path global variables.
+BUILD_FOLDER=""
+CACHE_FOLDER="cache"
+PYTHON_BIN=""
+PYTHON_LIB=""
+LOCAL_PYTHON_BINARY_DIST=""
+CLEAN_PYTHON_BINARY_DIST_CACHE=""
+BINARY_DIST_URI='http://chevah.com/binary'
+PIP_INDEX='http://chevah.com/pypi'
+PYTHON_VERSION="python2.7"
+
+# Load repo specific configuration.
+if [ -e paver.conf ]; then
+    source paver.conf
+fi
+
+
+# Put default values and create them as global variables.
+OS='not-detected-yet'
+ARCH='x86'
+
+
+clean_build() {
+    # Shortcut for clear since otherwise it will depend on python
+    echo "Removing ${BUILD_FOLDER}..."
+    delete_folder ${BUILD_FOLDER}
+    echo "Removing dist..."
+    delete_folder ${DIST_FOLDER}
+    echo "Removing publish..."
+    delete_folder 'publish'
+    echo "Cleaning project temporary files..."
+    rm -f DEFAULT_VALUES
+    echo "Cleaning pyc files ..."
+    if [ $OS = "rhel4" ]; then
+        # RHEL 4 don't support + option in -exec
+        # We use -print0 and xargs to no fork for each file.
+        # find will fail if no file is found.
+        touch ./dummy_file_for_RHEL4.pyc
+        find ./ -name '*.pyc' -print0 | xargs -0 rm
+    else
+        # AIX's find complains if there are no matching files when using +.
+        [ $(uname) == AIX ] && touch ./dummy_file_for_AIX.pyc
+        # Faster than '-exec rm {} \;' and supported in most OS'es,
+        # details at http://www.in-ulm.de/~mascheck/various/find/#xargs
+        find ./ -name '*.pyc' -exec rm {} +
+    fi
+    # In some case pip hangs with a build folder in temp and
+    # will not continue until it is manually removed.
+    rm -rf /tmp/pip*
+
+    if [ "$CLEAN_PYTHON_BINARY_DIST_CACHE" = "yes" ]; then
+        echo "Cleaning python binary ..."
+        rm -rf cache/python*
+    fi
+}
+
+
+#
+# Delete the folder as quickly as possible.
+#
+delete_folder() {
+    local target="$1"
+    # On Windows, we use internal command prompt for maximum speed.
+    # See: http://stackoverflow.com/a/6208144/539264
+    if [ $OS = "windows" -a -d $target ]; then
+        cmd //c "del /f/s/q $target > nul"
+        cmd //c "rmdir /s/q $target"
+    else
+        rm -rf $target
+    fi
+}
+
+
+#
+# Wrapper for executing a command and exiting on failure.
+#
+execute() {
+    if [ $DEBUG -ne 0 ]; then
+        echo "Executing:" $@
+    fi
+
+    #Make sure $@ is called in quotes as otherwise it will not work.
+    set +e
+    "$@"
+    exit_code=$?
+    set -e
+    if [ $exit_code -ne 0 ]; then
+        echo "Fail:" $@
+        exit 1
+    fi
+}
+
+#
+# Update global variables with current paths.
+#
+update_path_variables() {
+
+    if [ "${OS}" = "windows" ] ; then
+        PYTHON_BIN="/lib/python.exe"
+        PYTHON_LIB="/lib/Lib/"
+    else
+        PYTHON_BIN="/bin/python"
+        PYTHON_LIB="/lib/${PYTHON_VERSION}/"
+    fi
+
+    BUILD_FOLDER="build-${OS}-${ARCH}"
+    PYTHON_BIN="${BUILD_FOLDER}${PYTHON_BIN}"
+    PYTHON_LIB="${BUILD_FOLDER}${PYTHON_LIB}"
+
+    LOCAL_PYTHON_BINARY_DIST="$PYTHON_VERSION-$OS-$ARCH"
+
+    export PYTHONPATH=${BUILD_FOLDER}
+}
+
+
+write_default_values() {
+    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} > DEFAULT_VALUES
+}
+
+
+#
+# Install brink package.
+#
+install_brink() {
+    if [ "$BRINK_VERSION" = "skip" ]; then
+        echo "Skipping brink installation."
+        return
+    fi
+
+    echo "Installing version: chevah-brink==$BRINK_VERSION of brink..."
+
+    pip install "chevah-brink==$BRINK_VERSION"
+}
+
+
+#
+# Wrapper for python pip command.
+# * $1 - command name
+# * $2 - package_name and optional version.
+#
+pip() {
+    set +e
+    ${PYTHON_BIN} -m \
+        pip.__init__ $1 $2 \
+            --index-url=$PIP_INDEX/simple \
+            --download-cache=${CACHE_FOLDER} \
+            --find-links=file://${CACHE_FOLDER} \
+            --upgrade
+
+    exit_code=$?
+    set -e
+    if [ $exit_code -ne 0 ]; then
+        echo "Failed to install brink."
+        exit 1
+    fi
+}
+
+
+#
+# Download and extract a binary distribution in cache folder.
+#
+get_binary_dist() {
+    mkdir -p ${CACHE_FOLDER}
+    pushd ${CACHE_FOLDER}
+        get_tar_tz $1 $2
+    popd
+}
+
+
+#
+# Download a tar.gz archive and extract it in current folder.
+#
+get_tar_tz() {
+    local dist_name=$1
+    local remote_url=$2
+
+    echo "Getting $dist_name from $remote_url..."
+
+    tar_gz_file=${dist_name}.tar.gz
+    tar_file=${dist_name}.tar
+
+    # Get and extract archive.
+    rm -rf $dist_name
+    rm -f $tar_gz_file
+    rm -f $tar_file
+    # Use 1M dot to reduce console pollution.
+    execute wget --progress=dot -e dotbytes=1M $remote_url/${tar_gz_file}
+    execute gunzip $tar_gz_file
+    execute tar -xf $tar_file
+    rm -f $tar_gz_file
+    rm -f $tar_file
+}
+
+
+#
+# Copy python to build folder from binary distribution.
+#
+copy_python() {
+
+    local python_distributable="${CACHE_FOLDER}/${PYTHON_VERSION}-${OS}-${ARCH}"
+    local pip_package="pip-$PIP_VERSION"
+    local setuptools_package="setuptools-$SETUPTOOLS_VERSION"
+
+    # Check that python dist was installed
+    if [ ! -s ${PYTHON_BIN} ]; then
+        # Install python-dist since everything else depends on it.
+        echo "Bootstraping ${PYTHON_VERSION} environment to ${BUILD_FOLDER}..."
+        mkdir -p ${BUILD_FOLDER}
+
+        # If we don't have a cached python distributable,
+        # get one together with default build system.
+        if [ ! -d ${python_distributable} ]; then
+            echo "No ${PYTHON_VERSION} environment. Start downloading it..."
+            get_binary_dist \
+                ${PYTHON_VERSION}-${OS}-${ARCH} "$BINARY_DIST_URI/python"
+        fi
+        echo "Copying bootstraping files... "
+        cp -R ${python_distributable}/* ${BUILD_FOLDER}
+
+        # Backwards compatibility with python 2.5 build.
+        if [[ "$PYTHON_VERSION" = "python2.5" ]]; then
+            # Copy include files.
+            if [ -d ${BUILD_FOLDER}/lib/config/include ]; then
+                cp -r ${BUILD_FOLDER}/lib/config/include ${BUILD_FOLDER}
+            fi
+
+            # Copy pywintypes25.dll as it is required by paver on windows.
+            if [ "$OS" = "windows" ]; then
+                cp -R ${BUILD_FOLDER}/lib/pywintypes25.dll . || true
+            fi
+        fi
+
+        if [ ! -d ${CACHE_FOLDER}/$pip_package ]; then
+            echo "No ${pip_package}. Start downloading it..."
+            get_binary_dist "$pip_package" "$PIP_INDEX/packages"
+        fi
+        cp -RL "${CACHE_FOLDER}/$pip_package/pip" ${PYTHON_LIB}/site-packages/
+
+        if [ ! -d ${CACHE_FOLDER}/$setuptools_package ]; then
+            echo "No ${setuptools_package}. Start downloading it..."
+            get_binary_dist "$setuptools_package" "$PIP_INDEX/packages"
+        fi
+        cp -RL "${CACHE_FOLDER}/$setuptools_package/setuptools" \
+            ${PYTHON_LIB}/site-packages/
+        cp -RL "${CACHE_FOLDER}/$setuptools_package/setuptools.egg-info" \
+            ${PYTHON_LIB}/site-packages/
+        cp "${CACHE_FOLDER}/$setuptools_package/pkg_resources.py" \
+            ${PYTHON_LIB}/site-packages/
+        cp "${CACHE_FOLDER}/$setuptools_package/easy_install.py" \
+            ${PYTHON_LIB}/site-package
+
+        # Once we have pip, we can use it.
+        pip install "paver==$PAVER_VERSION"
+
+        WAS_PYTHON_JUST_INSTALLED=1
+    fi
+
+}
+
+
+#
+# Make sure a python environment is available at path.
+#
+distributable_python() {
+
+    PIP_VERSION="6.1.1"
+    SETUPTOOLS_VERSION="15.0"
+
+    local destination=$1
+
+    local python_distributable="${CACHE_FOLDER}/${PYTHON_VERSION}-${OS}-${ARCH}"
+    local pip_package="pip-$PIP_VERSION"
+
+    if [ "${OS}" = "windows" ] ; then
+        local python_bin="lib/python.exe"
+    else
+        local python_bin="bin/python"
+    fi
+
+    # Check that python dist was installed
+    if [ -s $destination/$python_bin ]; then
+        return 0
+    fi
+
+    get_tar_tz ${PYTHON_VERSION}-${OS}-${ARCH} "$BINARY_DIST_URI/python"
+    echo "Bootstraping ${PYTHON_VERSION} environment to $destination..."
+    mv ${PYTHON_VERSION}-${OS}-${ARCH} $destination
+
+    pushd $destination
+        execute wget https://bootstrap.pypa.io/get-pip.py
+        execute $python_bin get-pip.py
+    popd
+}
+
+#
+# Install dependencies after python was just installed.
+#
+install_dependencies(){
+
+    if [ $WAS_PYTHON_JUST_INSTALLED -ne 1 ]; then
+        return
+    fi
+
+    install_brink
+
+    set +e
+    ${PYTHON_BIN} -c 'from paver.tasks import main; main()' deps
+    exit_code=$?
+    set -e
+    if [ $exit_code -ne 0 ]; then
+        echo 'Failed to run the initial "paver deps" command.'
+        exit 1
+    fi
+}
+
+
+#
+# Check that we have a pavement.py in the current dir.
+# otherwise it means we are out of the source folder and paver can not be
+# used there.
+#
+check_source_folder() {
+
+    if [ ! -e pavement.py ]; then
+        echo 'No pavement.py file found in current folder.'
+        echo 'Make sure you are running paver from a source folder.'
+        exit 1
+    fi
+}
+
+
+#
+# Check version of current OS to see if it is supported.
+# If it's too old, exit with a nice informative message.
+# If it's supported, return through eval the version numbers to be used for
+# naming the package, for example '5' for RHEL 5.x, '1204' for Ubuntu 12.04',
+# '53' for AIX 5.3.x.x , '10' for Solaris 10 or '1010' for OS X 10.10.1.
+#
+check_os_version() {
+    # First parameter should be the human-readable name for the current OS.
+    # For example: "Red Hat Enterprise Linux" for RHEL, "OS X" for Darwin etc.
+    # Second and third parameters must be strings composed of integers
+    # delimited with dots, representing, in order, the oldest version
+    # supported for the current OS and the current detected version.
+    # The fourth parameter is used to return through eval the relevant numbers
+    # for naming the Python package for the current OS, as detailed above.
+    local name_fancy="$1"
+    local version_good="$2"
+    local version_raw="$3"
+    local version_chevah="$4"
+    local version_constructed=''
+    local flag_supported='good_enough'
+    local version_raw_array
+    local version_good_array
+
+    # Using '.' as a delimiter, populate the version_raw_* arrays.
+    IFS=. read -a version_raw_array <<< "$version_raw"
+    IFS=. read -a version_good_array <<< "$version_good"
+
+    # Iterate through all the integers from the good version to compare them
+    # one by one with the corresponding integers from the supported version.
+    for (( i=0 ; i < ${#version_good_array[@]}; i++ )); do
+        version_constructed="${version_constructed}${version_raw_array[$i]}"
+        if [ ${version_raw_array[$i]} -gt ${version_good_array[$i]} -a \
+            "$flag_supported" = 'good_enough' ]; then
+            flag_supported='true'
+        elif [  ${version_raw_array[$i]} -lt ${version_good_array[$i]} -a \
+            "$flag_supported" = 'good_enough' ]; then
+            flag_supported='false'
+        fi
+    done
+
+    if [ "$flag_supported" = 'false' ]; then
+        echo "The current version of ${name_fancy} is too old: ${version_raw}"
+        echo "Oldest supported version of ${name_fancy} is: ${version_good}"
+        exit 13
+    fi
+
+    # The sane way to return fancy values with a bash function is to use eval.
+    eval $version_chevah="'$version_constructed'"
+}
+
+
+#
+# Update OS and ARCH variables with the current values.
+#
+detect_os() {
+
+    OS=$(uname -s | tr "[A-Z]" "[a-z]")
+
+    if [ "${OS%mingw*}" = "" ]; then
+
+        OS='windows'
+        ARCH='x86'
+
+    elif [ "${OS}" = "sunos" ]; then
+
+        ARCH=$(isainfo -n)
+        os_version_raw=$(uname -r | cut -d'.' -f2)
+        check_os_version Solaris 10 "$os_version_raw" os_version_chevah
+
+        OS="solaris${os_version_chevah}"
+
+    elif [ "${OS}" = "aix" ]; then
+
+        ARCH="ppc$(getconf HARDWARE_BITMODE)"
+        os_version_raw=$(oslevel)
+        check_os_version AIX 5.3 "$os_version_raw" os_version_chevah
+
+        OS="aix${os_version_chevah}"
+
+    elif [ "${OS}" = "hp-ux" ]; then
+
+        ARCH=$(uname -m)
+        os_version_raw=$(uname -r | cut -d'.' -f2-)
+        check_os_version HP-UX 11.31 "$os_version_raw" os_version_chevah
+
+        OS="hpux${os_version_chevah}"
+
+    elif [ "${OS}" = "linux" ]; then
+
+        ARCH=$(uname -m)
+
+        if [ -f /etc/redhat-release ]; then
+            # Avoid getting confused by Red Hat derivatives such as Fedora.
+            egrep 'Red\ Hat|CentOS|Scientific' /etc/redhat-release > /dev/null
+            if [ $? -eq 0 ]; then
+                os_version_raw=$(\
+                    cat /etc/redhat-release | sed s/.*release// | cut -d' ' -f2)
+                check_os_version "Red Hat Enterprise Linux" 4 \
+                    "$os_version_raw" os_version_chevah
+                OS="rhel${os_version_chevah}"
+            fi
+        elif [ -f /etc/SuSE-release ]; then
+            # Avoid getting confused by SUSE derivatives such as OpenSUSE.
+            if [ $(head -n1 /etc/SuSE-release | cut -d' ' -f1) = 'SUSE' ]; then
+                os_version_raw=$(\
+                    grep VERSION /etc/SuSE-release | cut -d' ' -f3)
+                check_os_version "SUSE Linux Enterprise Server" 11 \
+                    "$os_version_raw" os_version_chevah
+                OS="sles${os_version_chevah}"
+            fi
+        elif [ $(command -v lsb_release) ]; then
+            lsb_release_id=$(lsb_release -is)
+            os_version_raw=$(lsb_release -rs)
+            if [ $lsb_release_id = Ubuntu ]; then
+                check_os_version "Ubuntu Long-term Support" 10.04 \
+                    "$os_version_raw" os_version_chevah
+                # Only Long-term Support versions are oficially endorsed, thus
+                # $os_version_chevah should end in 04 and the first two digits
+                # should represent an even year.
+                if [ ${os_version_chevah%%04} != ${os_version_chevah} -a \
+                    $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
+                    OS="ubuntu${os_version_chevah}"
+                fi
+            fi
+        fi
+
+    elif [ "${OS}" = "darwin" ]; then
+        ARCH=$(uname -m)
+
+        os_version_raw=$(sw_vers -productVersion)
+        check_os_version "Mac OS X" 10.4 "$os_version_raw" os_version_chevah
+
+        # For now, no matter the actual OS X version returned, we use '108'.
+        OS="osx108"
+
+    else
+        echo 'Unsupported operating system:' $OS
+        exit 14
+    fi
+
+    # Fix arch names.
+    if [ "$ARCH" = "i686" -o "$ARCH" = "i386" ]; then
+        ARCH='x86'
+    elif [ "$ARCH" = "x86_64" -o "$ARCH" = "amd64" ]; then
+        ARCH='x64'
+    elif [ "$ARCH" = "sparcv9" ]; then
+        ARCH='sparc64'
+    elif [ "$ARCH" = "ppc64" ]; then
+        # Python has not been fully tested on AIX when compiled as a 64 bit
+        # application and has math rounding error problems (at least with XL C).
+        ARCH='ppc'
+    elif [ "$ARCH" = "aarch64" ]; then
+        ARCH='arm64'
+    fi
+}
+
+detect_os
+update_path_variables
+
+if [ "$COMMAND" = "clean" ] ; then
+    clean_build
+    exit 0
+fi
+
+if [ "$COMMAND" = "detect_os" ] ; then
+    write_default_values
+    exit 0
+fi
+
+if [ "$COMMAND" = "get_python" ] ; then
+    get_binary_dist $2 "$BINARY_DIST_URI/python"
+    exit 0
+fi
+
+if [ "$COMMAND" = "get_agent" ] ; then
+    get_binary_dist $2 "$BINARY_DIST_URI/agent"
+    exit 0
+fi
+
+if [ "$COMMAND" = "distributable_python" ] ; then
+    distributable_python $2
+    exit $?
+fi
+
+check_source_folder
+write_default_values
+copy_python
+install_dependencies
+
+# Always update brink when running buildbot tasks.
+for paver_task in "deps" "test_os_dependent" "test_os_independent"; do
+    if [ "$COMMAND" == "$paver_task" ] ; then
+        install_brink
+    fi
+done
+
+# Now that we have Python and Paver, let's call Paver from Python :)
+set +e
+${PYTHON_BIN} -c 'from paver.tasks import main; main()' "$@"
+exit_code=$?
+set -e
+exit $exit_code

--- a/paver.sh
+++ b/paver.sh
@@ -322,7 +322,7 @@ distributable_python() {
     local pip_package="pip-$PIP_VERSION"
 
     if [ "${OS}" = "windows" ] ; then
-        local python_bin="lib/python.exe"
+        local python_bin="python.exe"
     else
         local python_bin="bin/python"
     fi
@@ -334,7 +334,9 @@ distributable_python() {
 
     get_tar_tz ${PYTHON_VERSION}-${OS}-${ARCH} "$BINARY_DIST_URI/python"
     echo "Bootstraping ${PYTHON_VERSION} environment to $destination..."
-    mv ${PYTHON_VERSION}-${OS}-${ARCH} $destination
+    # Our Windows python-package has the venv in lib folder.
+    mv ${PYTHON_VERSION}-${OS}-${ARCH}/lib $destination
+    rm -rf ${PYTHON_VERSION}-${OS}-${ARCH}
 
     pushd $destination
         execute wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Relese notes for Chevah KeyCert
 ###############################
 
 
+1.3.2 - 14/04/2015
+==================
+
+* Update error message to show name for unknown key type.
+* Fix handling of Unicode path on Unix/Linux.
+
+
 1.3.1 - 08/04/2015
 ==================
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -5,7 +5,6 @@ Relese notes for Chevah KeyCert
 1.3.2 - 14/04/2015
 ==================
 
-* Update error message to show name for unknown key type.
 * Fix handling of Unicode path on Unix/Linux.
 * Remove support for generating SSL DSA keys.
 * Rename generate_ssh_key_subparser to generate_ssh_key_parser

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -7,6 +7,8 @@ Relese notes for Chevah KeyCert
 
 * Update error message to show name for unknown key type.
 * Fix handling of Unicode path on Unix/Linux.
+* Remove support for generating SSL DSA keys.
+* Rename generate_ssh_key_subparser to generate_ssh_key_parser
 
 
 1.3.1 - 08/04/2015

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.3.1'
+VERSION = '1.3.2'
 
 
 class NoseTestCommand(TestCommand):


### PR DESCRIPTION
Problem
======

This started due to the fact that key type is not listed for unknown errors.
While working on this I found out that our current Windows and OSX versions don't support DSA key types.

Due to this we should remove the key type from CSR generations.

DSA will be removed from TLS 1.3 and I don't think there are many people using it.


Changes
======

Removed --key-type

I have also comitted first code to allow running test on Win/OS X in our test environment.


How to test
========

reviewers: @alibotean 

check that changes make sense.

make test might still not work on your computer... it works on buildbot windows slave. .. i would like to continue working on this in #17

You can force the creating of the virtual env using .. it should create the same env as on buildslave
```
make ci_deps
```

You might need to clean your previous env with `make clean`

Please also try to use the demo command to generate certificates in unicode
```
python keycert-demo.py ssl-gen-key
```
