### PR TITLE
Sign key with sha1 on Solaris 10 on other systems which don't support sha256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,6 @@ endif
 
 test_remote_with_clean:
 	$(BUILDBOT_TRY) -b $(TARGET) --properties=force_clean=yes
+
+test_remote_with_wait:
+	$(BUILDBOT_TRY) -b $(TARGET) --wait

--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,19 @@ endif
 dev_deps:
 	@$(BASE_PATH)/pip install buildbot
 
-test_remote:
+git_push:
+	@echo 'Sending commited changes before sending patch'
+	@git push
+
+test_remote: git_push
 ifeq "$(TARGET)" ""
 	$(BUILDBOT_TRY) --get-builder-names | grep keycert
 else
 	$(BUILDBOT_TRY) -b $(TARGET)
 endif
 
-test_remote_with_clean:
+test_remote_with_clean: git_push
 	$(BUILDBOT_TRY) -b $(TARGET) --properties=force_clean=yes
 
-test_remote_with_wait:
+test_remote_with_wait: git_push
 	$(BUILDBOT_TRY) -b $(TARGET) --wait

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ It depends on these C modules:
 
 It provides the following functionalities:
 
-* Generate SSL key and self signed SSL certificate.
-* Generate SSL key and CSR.
+* Generate SSL key and self signed SSL certificate signed with SHA1.
+* Generate SSL key and CSR. Signed with SHA256 or fall back to SHA1.
 * Generate RSA/DSA keys.
 * Convert OpenSSH, SSH.com, Putty, LSH.
 * Populate an argparser subparser with command line options.

--- a/chevah/keycert/__init__.py
+++ b/chevah/keycert/__init__.py
@@ -5,10 +5,10 @@ import os
 import sys
 
 
-def _path(path, encoding):
+def _path(path, encoding='utf-8'):
     if os.name != 'posix' or sys.platform.startswith('darwin'):
         # On Windows and OSX we always use unicode.
         # We don't run yet tests on Windows and OSX.
         return path  # pragma: no cover
 
-    return path.encode('utf-8')
+    return path.encode(encoding)

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -132,10 +132,7 @@ def generate_ssh_key(options, open_method=None):
 
         key = Key.generate(key_type=key_type, key_size=key_size)
 
-        private_file_path = local_filesystem.getEncodedPath(private_file)
-        public_file_path = local_filesystem.getEncodedPath(public_file)
-
-        with open_method(private_file_path, 'wb') as file_handler:
+        with open_method(_path(private_file), 'wb') as file_handler:
             _store_OpenSSH(key, private_file=file_handler)
 
         key_comment = None
@@ -145,7 +142,7 @@ def generate_ssh_key(options, open_method=None):
         else:
             message_comment = u'without a comment'
 
-        with open_method(public_file_path, 'wb') as file_handler:
+        with open_method(_path(public_file), 'wb') as file_handler:
             _store_OpenSSH(key, public_file=file_handler, comment=key_comment)
 
         message = (

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -119,7 +119,7 @@ def generate_ssh_key(options, open_method=None):
         key_type = options.key_type.lower()
 
         if not hasattr(options, 'key_file') or options.key_file is None:
-            options.key_file = 'id_%s' % (key_type)
+            options.key_file = u'id_%s' % (key_type)
 
         private_file = options.key_file
 

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -139,6 +139,9 @@ def _generate_csr(options):
     """
     Helper to catch all crypto errors and reduce indentation.
     """
+    if options.key_size < 512:
+        raise KeyCertException('Key size must be greater than 512.')
+
     key_type = crypto.TYPE_RSA
 
     csr = crypto.X509Req()

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -188,7 +188,12 @@ def _generate_csr(options):
 
     csr.add_extensions(extensions)
     csr.set_pubkey(key)
-    csr.sign(key, 'sha256')
+
+    try:
+        csr.sign(key, 'sha256')
+    except ValueError:
+        # If SHA256 is not supported, fallback to sha1.
+        cert.sign(key, 'sha1')
 
     csr_pem = crypto.dump_certificate_request(crypto.FILETYPE_PEM, csr)
     if options.key_password:

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -193,7 +193,7 @@ def _generate_csr(options):
         csr.sign(key, 'sha256')
     except ValueError:
         # If SHA256 is not supported, fallback to sha1.
-        cert.sign(key, 'sha1')
+        csr.sign(key, 'sha1')
 
     csr_pem = crypto.dump_certificate_request(crypto.FILETYPE_PEM, csr)
     if options.key_password:

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -194,7 +194,7 @@ def _generate_csr(options):
 
     try:
         csr.sign(key, 'sha256')
-    except ValueError:
+    except ValueError:  # pragma: no cover
         # If SHA256 is not supported, fallback to sha1.
         csr.sign(key, 'sha1')
 

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -1811,11 +1811,13 @@ class Testgenerate_ssh_key(EmpiricalTestCase, CommandLineMixin):
         When custom values are provided, the key is generated using those
         values.
         """
+        file_name = mk.string()
+        file_name_pub = file_name + u'.pub'
         options = self.parseArguments([
             self.sub_command_name,
             '--key-size=512',
             '--key-type=DSA',
-            '--key-file=test_file',
+            u'--key-file=' + file_name,
             '--key-comment=this is a comment',
             ])
         open_method = DummyOpenContext()
@@ -1828,14 +1830,14 @@ class Testgenerate_ssh_key(EmpiricalTestCase, CommandLineMixin):
 
         # First it writes the private key.
         first_file = open_method.calls.pop(0)
-        self.assertPathEqual(u'test_file', first_file['path'])
+        self.assertPathEqual(file_name, first_file['path'])
         self.assertEqual('wb', first_file['mode'])
         self.assertEqual(
             key.toString('openssh'), first_file['stream'].getvalue())
 
         # Second it writes the public key.
         second_file = open_method.calls.pop(0)
-        self.assertPathEqual(u'test_file.pub', second_file['path'])
+        self.assertPathEqual(file_name_pub, second_file['path'])
         self.assertEqual('wb', second_file['mode'])
         self.assertEqual(
             key.public().toString('openssh', 'this is a comment'),
@@ -1843,8 +1845,9 @@ class Testgenerate_ssh_key(EmpiricalTestCase, CommandLineMixin):
 
         self.assertEqual(
             u'SSH key of type "dsa" and length "512" generated as public '
-            u'key file "test_file.pub" and private key file "test_file" '
-            u'having comment "this is a comment".',
+            u'key file "%s" and private key file "%s" '
+            u'having comment "this is a comment".' % (
+                file_name_pub, file_name),
             message,
             )
         self.assertEqual(0, exit_code)

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -1798,6 +1798,14 @@ class Testgenerate_ssh_key(EmpiricalTestCase, CommandLineMixin):
             help='Available sub-commands', dest='sub_command')
         generate_ssh_key_parser(subparser, self.sub_command_name)
 
+    def assertPathEqual(self, expected, actual):
+        """
+        Check that pats are equal.
+        """
+        if self.os_family == 'posix':
+            expected = expected.encode('utf-8')
+        self.assertEqual(expected, actual)
+
     def test_generate_ssh_key_custom_values(self):
         """
         When custom values are provided, the key is generated using those
@@ -1820,14 +1828,14 @@ class Testgenerate_ssh_key(EmpiricalTestCase, CommandLineMixin):
 
         # First it writes the private key.
         first_file = open_method.calls.pop(0)
-        self.assertEqual('test_file', first_file['path'])
+        self.assertPathEqual(u'test_file', first_file['path'])
         self.assertEqual('wb', first_file['mode'])
         self.assertEqual(
             key.toString('openssh'), first_file['stream'].getvalue())
 
         # Second it writes the public key.
         second_file = open_method.calls.pop(0)
-        self.assertEqual('test_file.pub', second_file['path'])
+        self.assertPathEqual(u'test_file.pub', second_file['path'])
         self.assertEqual('wb', second_file['mode'])
         self.assertEqual(
             key.public().toString('openssh', 'this is a comment'),
@@ -1861,14 +1869,14 @@ class Testgenerate_ssh_key(EmpiricalTestCase, CommandLineMixin):
 
         # First it writes the private key.
         first_file = open_method.calls.pop(0)
-        self.assertEqual('id_rsa', first_file['path'])
+        self.assertPathEqual(u'id_rsa', first_file['path'])
         self.assertEqual('wb', first_file['mode'])
         self.assertEqual(
             key.toString('openssh'), first_file['stream'].getvalue())
 
         # Second it writes the public key.
         second_file = open_method.calls.pop(0)
-        self.assertEqual('id_rsa.pub', second_file['path'])
+        self.assertPathEqual(u'id_rsa.pub', second_file['path'])
         self.assertEqual('wb', second_file['mode'])
         self.assertEqual(
             key.public().toString('openssh'), second_file['stream'].getvalue())

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -190,7 +190,8 @@ class Test_generate_csr(CommandLineTestBase):
         with self.assertRaises(KeyCertException) as context:
             generate_csr(options)
 
-        self.assertEqual('key size too small', context.exception.message)
+        self.assertEqual(
+            'Key size must be greater than 512.', context.exception.message)
 
     def test_bad_country_long(self):
         """

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -19,7 +19,7 @@ from chevah.keycert.ssl import (
     generate_and_store_csr,
     )
 
-parser = argparse.ArgumentParser(prog='PROG', prefix_chars='-+')
+parser = argparse.ArgumentParser(prog='PROG')
 subparser = parser.add_subparsers(
             help='Available sub-commands', dest='sub_command')
 

--- a/paver.sh
+++ b/paver.sh
@@ -323,8 +323,10 @@ distributable_python() {
 
     if [ "${OS}" = "windows" ] ; then
         local python_bin="python.exe"
+        local venv_path=${PYTHON_VERSION}-${OS}-${ARCH}/lib
     else
         local python_bin="bin/python"
+        local venv_path=${PYTHON_VERSION}-${OS}-${ARCH}
     fi
 
     # Check that python dist was installed
@@ -335,7 +337,7 @@ distributable_python() {
     get_tar_tz ${PYTHON_VERSION}-${OS}-${ARCH} "$BINARY_DIST_URI/python"
     echo "Bootstraping ${PYTHON_VERSION} environment to $destination..."
     # Our Windows python-package has the venv in lib folder.
-    mv ${PYTHON_VERSION}-${OS}-${ARCH}/lib $destination
+    mv ${venv_path} $destination
     rm -rf ${PYTHON_VERSION}-${OS}-${ARCH}
 
     pushd $destination

--- a/paver.sh
+++ b/paver.sh
@@ -49,7 +49,7 @@ WAS_PYTHON_JUST_INSTALLED=0
 DIST_FOLDER='dist'
 
 # Path global variables.
-BUILD_FOLDER=""
+BUILD_FOLDER="build"
 CACHE_FOLDER="cache"
 PYTHON_BIN=""
 PYTHON_LIB=""
@@ -153,7 +153,6 @@ update_path_variables() {
         PYTHON_LIB="/lib/${PYTHON_VERSION}/"
     fi
 
-    BUILD_FOLDER="build-${OS}-${ARCH}"
     PYTHON_BIN="${BUILD_FOLDER}${PYTHON_BIN}"
     PYTHON_LIB="${BUILD_FOLDER}${PYTHON_LIB}"
 
@@ -162,59 +161,6 @@ update_path_variables() {
     export PYTHONPATH=${BUILD_FOLDER}
 }
 
-
-write_default_values() {
-    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} > DEFAULT_VALUES
-}
-
-
-#
-# Install brink package.
-#
-install_brink() {
-    if [ "$BRINK_VERSION" = "skip" ]; then
-        echo "Skipping brink installation."
-        return
-    fi
-
-    echo "Installing version: chevah-brink==$BRINK_VERSION of brink..."
-
-    pip install "chevah-brink==$BRINK_VERSION"
-}
-
-
-#
-# Wrapper for python pip command.
-# * $1 - command name
-# * $2 - package_name and optional version.
-#
-pip() {
-    set +e
-    ${PYTHON_BIN} -m \
-        pip.__init__ $1 $2 \
-            --index-url=$PIP_INDEX/simple \
-            --download-cache=${CACHE_FOLDER} \
-            --find-links=file://${CACHE_FOLDER} \
-            --upgrade
-
-    exit_code=$?
-    set -e
-    if [ $exit_code -ne 0 ]; then
-        echo "Failed to install brink."
-        exit 1
-    fi
-}
-
-
-#
-# Download and extract a binary distribution in cache folder.
-#
-get_binary_dist() {
-    mkdir -p ${CACHE_FOLDER}
-    pushd ${CACHE_FOLDER}
-        get_tar_tz $1 $2
-    popd
-}
 
 
 #
@@ -239,72 +185,6 @@ get_tar_tz() {
     execute tar -xf $tar_file
     rm -f $tar_gz_file
     rm -f $tar_file
-}
-
-
-#
-# Copy python to build folder from binary distribution.
-#
-copy_python() {
-
-    local python_distributable="${CACHE_FOLDER}/${PYTHON_VERSION}-${OS}-${ARCH}"
-    local pip_package="pip-$PIP_VERSION"
-    local setuptools_package="setuptools-$SETUPTOOLS_VERSION"
-
-    # Check that python dist was installed
-    if [ ! -s ${PYTHON_BIN} ]; then
-        # Install python-dist since everything else depends on it.
-        echo "Bootstraping ${PYTHON_VERSION} environment to ${BUILD_FOLDER}..."
-        mkdir -p ${BUILD_FOLDER}
-
-        # If we don't have a cached python distributable,
-        # get one together with default build system.
-        if [ ! -d ${python_distributable} ]; then
-            echo "No ${PYTHON_VERSION} environment. Start downloading it..."
-            get_binary_dist \
-                ${PYTHON_VERSION}-${OS}-${ARCH} "$BINARY_DIST_URI/python"
-        fi
-        echo "Copying bootstraping files... "
-        cp -R ${python_distributable}/* ${BUILD_FOLDER}
-
-        # Backwards compatibility with python 2.5 build.
-        if [[ "$PYTHON_VERSION" = "python2.5" ]]; then
-            # Copy include files.
-            if [ -d ${BUILD_FOLDER}/lib/config/include ]; then
-                cp -r ${BUILD_FOLDER}/lib/config/include ${BUILD_FOLDER}
-            fi
-
-            # Copy pywintypes25.dll as it is required by paver on windows.
-            if [ "$OS" = "windows" ]; then
-                cp -R ${BUILD_FOLDER}/lib/pywintypes25.dll . || true
-            fi
-        fi
-
-        if [ ! -d ${CACHE_FOLDER}/$pip_package ]; then
-            echo "No ${pip_package}. Start downloading it..."
-            get_binary_dist "$pip_package" "$PIP_INDEX/packages"
-        fi
-        cp -RL "${CACHE_FOLDER}/$pip_package/pip" ${PYTHON_LIB}/site-packages/
-
-        if [ ! -d ${CACHE_FOLDER}/$setuptools_package ]; then
-            echo "No ${setuptools_package}. Start downloading it..."
-            get_binary_dist "$setuptools_package" "$PIP_INDEX/packages"
-        fi
-        cp -RL "${CACHE_FOLDER}/$setuptools_package/setuptools" \
-            ${PYTHON_LIB}/site-packages/
-        cp -RL "${CACHE_FOLDER}/$setuptools_package/setuptools.egg-info" \
-            ${PYTHON_LIB}/site-packages/
-        cp "${CACHE_FOLDER}/$setuptools_package/pkg_resources.py" \
-            ${PYTHON_LIB}/site-packages/
-        cp "${CACHE_FOLDER}/$setuptools_package/easy_install.py" \
-            ${PYTHON_LIB}/site-package
-
-        # Once we have pip, we can use it.
-        pip install "paver==$PAVER_VERSION"
-
-        WAS_PYTHON_JUST_INSTALLED=1
-    fi
-
 }
 
 
@@ -344,42 +224,6 @@ distributable_python() {
         execute wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
         execute $python_bin get-pip.py
     popd
-}
-
-#
-# Install dependencies after python was just installed.
-#
-install_dependencies(){
-
-    if [ $WAS_PYTHON_JUST_INSTALLED -ne 1 ]; then
-        return
-    fi
-
-    install_brink
-
-    set +e
-    ${PYTHON_BIN} -c 'from paver.tasks import main; main()' deps
-    exit_code=$?
-    set -e
-    if [ $exit_code -ne 0 ]; then
-        echo 'Failed to run the initial "paver deps" command.'
-        exit 1
-    fi
-}
-
-
-#
-# Check that we have a pavement.py in the current dir.
-# otherwise it means we are out of the source folder and paver can not be
-# used there.
-#
-check_source_folder() {
-
-    if [ ! -e pavement.py ]; then
-        echo 'No pavement.py file found in current folder.'
-        echo 'Make sure you are running paver from a source folder.'
-        exit 1
-    fi
 }
 
 
@@ -540,6 +384,10 @@ detect_os() {
     fi
 }
 
+if [ $OS = "ubuntu1204" -a $ARCH = "x86" ]; then
+    OS='linux'
+fi
+
 detect_os
 update_path_variables
 
@@ -548,41 +396,17 @@ if [ "$COMMAND" = "clean" ] ; then
     exit 0
 fi
 
-if [ "$COMMAND" = "detect_os" ] ; then
-    write_default_values
-    exit 0
+if [ "$COMMAND" = "ci_deps" ] ; then
+    make ci_deps
+    exit $?
 fi
 
-if [ "$COMMAND" = "get_python" ] ; then
-    get_binary_dist $2 "$BINARY_DIST_URI/python"
-    exit 0
-fi
-
-if [ "$COMMAND" = "get_agent" ] ; then
-    get_binary_dist $2 "$BINARY_DIST_URI/agent"
-    exit 0
+if [ "$COMMAND" = "ci_test" ] ; then
+    make ci_test
+    exit $?
 fi
 
 if [ "$COMMAND" = "distributable_python" ] ; then
     distributable_python $2
     exit $?
 fi
-
-check_source_folder
-write_default_values
-copy_python
-install_dependencies
-
-# Always update brink when running buildbot tasks.
-for paver_task in "deps" "test_os_dependent" "test_os_independent"; do
-    if [ "$COMMAND" == "$paver_task" ] ; then
-        install_brink
-    fi
-done
-
-# Now that we have Python and Paver, let's call Paver from Python :)
-set +e
-${PYTHON_BIN} -c 'from paver.tasks import main; main()' "$@"
-exit_code=$?
-set -e
-exit $exit_code

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Relese notes for Chevah KeyCert
 ###############################
 
 
+1.3.3 - 17/04/2015
+==================
+
+* Fall back to sha1 when sha256 is not available on OS to sign CSR.
+
+
 1.3.2 - 14/04/2015
 ==================
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -6,6 +6,7 @@ Relese notes for Chevah KeyCert
 ==================
 
 * Fall back to sha1 when sha256 is not available on OS to sign CSR.
+* Don't allow creating RSA keys less than 512.
 
 
 1.3.2 - 14/04/2015

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.3.2'
+VERSION = '1.3.3'
 
 
 class NoseTestCommand(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
             'chevah-empirical ==0.33.1',
             'pyflakes ==0.8.1',
             'pocketlint ==1.4.4.c10',
-            'pep8 ==1.6.1',
+            'pep8 ==1.6.2',
             'nose',
             'mock',
             'bunch',


### PR DESCRIPTION
Problem
======

Sha256 is not supported on solaris 10 and CSR fails.


Changes
=======

Fallback to sha1.

On  Solaris the openssl locks when trying to create small keys .. less than 50bits... so I have updated the code to not allow less than 512.

As a drive by I have updated the test to pass on windows.


How to test
=========

reviewers: @alibotean 

check that changes make sense

with the changes I hope that you can run the test on your computer

solaris 10 build is here http://build.chevah.com/builders/keycert-solaris-10/builds/14