### PR TITLE
SSH code coverage cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "2.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - python setup.py test -q
 
 after_success:
-  - coveralls
+  - codecov
 
 # Only run test when committing to master branch.
 # PR tests will still be executed.

--- a/README.rst
+++ b/README.rst
@@ -33,5 +33,5 @@ Release is done automatically for each tag, using Travis-CI.
 .. image:: https://travis-ci.org/chevah/chevah-keycert.svg?branch=master
     :target: https://travis-ci.org/chevah/chevah-keycert
 
-.. image:: https://img.shields.io/coveralls/chevah/chevah-keycert/master.svg
-    :target: https://coveralls.io/r/chevah/chevah-keycert?branch=master
+.. image:: https://codecov.io/github/chevah/chevah-keycert/coverage.svg?branch=master
+    :target: https://codecov.io/github/chevah/chevah-keycert?branch=master

--- a/chevah/keycert/common.py
+++ b/chevah/keycert/common.py
@@ -14,7 +14,7 @@ import sys
 
 _PY3 = sys.version_info > (3,)
 
-if _PY3:     # pragma: no cover
+if _PY3:  # pragma: no cover
     long = int
     unicode = str
     izip = zip

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -419,20 +419,6 @@ class Key(object):
         """
         return self.keyObject.size() + 1
 
-    @property
-    def private_openssh(self):
-        """
-        Return the OpenSSH representation for the public key part.
-        """
-        return self.toString(type='openssh')
-
-    @property
-    def public_openssh(self):
-        """
-        Return the OpenSSH representation for private key part.
-        """
-        return self.public().toString(type='openssh')
-
     def type(self):
         """
         Return the type of the object we wrap.  Currently this can only be
@@ -449,7 +435,7 @@ class Key(object):
                 'unknown type of object: %r' % (self.keyObject,))
         if type in ('RSA', 'DSA'):
             return type
-        else:
+        else:  # pragma: no cover
             raise RuntimeError('unknown type of key: %s' % (type,))
 
     def sshType(self):
@@ -503,7 +489,9 @@ class Key(object):
             return (common.NS(b'ssh-dss') + common.MP(data['p']) +
                     common.MP(data['q']) + common.MP(data['g']) +
                     common.MP(data['y']))
-        else:
+        else:  # pragma: no cover
+            # Under normal usage we should not be able to reach this
+            # branch. First self.type() will raise an error.
             raise BadKeyError("unknown key type %s" % (type,))
 
     def privateBlob(self):
@@ -595,7 +583,8 @@ class Key(object):
             # Make sure they are padded out to 160 bits (20 bytes each)
             ret = common.NS(Util.number.long_to_bytes(sig[0], 20) +
                             Util.number.long_to_bytes(sig[1], 20))
-        else:
+        else:  # pragma: no cover
+            # We should not hit this branch under normal usage.
             raise BadKeyError('unknown key type %s' % (self.type(),))
         return common.NS(self.sshType()) + ret
 
@@ -622,7 +611,7 @@ class Key(object):
             numbers = [Util.number.bytes_to_long(n) for n in (signature[:20],
                        signature[20:])]
             digest = sha1(data).digest()
-        else:
+        else:  # pragma: no cover
             raise BadKeyError('unknown key type %s' % (self.type(),))
         return self.keyObject.verify(digest, numbers)
 
@@ -940,7 +929,7 @@ class Key(object):
                                         [b'q', common.MP(data['q'])[4:]],
                                         [b'g', common.MP(data['g'])[4:]],
                                         [b'y', common.MP(data['y'])[4:]]]]])
-            else:
+            else:  # pragma: no cover
                 raise BadKeyError("unknown key type %s" % (type,))
             return (b'{' + base64.encodestring(keyData).replace(b'\n', b'') +
                     b'}')
@@ -967,7 +956,7 @@ class Key(object):
                                      [b'g', common.MP(data['g'])[4:]],
                                      [b'y', common.MP(data['y'])[4:]],
                                      [b'x', common.MP(data['x'])[4:]]]]])
-            else:
+            else:  # pragma: no cover
                 raise BadKeyError("unknown key type %s'" % (type,))
 
     @classmethod
@@ -1013,7 +1002,7 @@ class Key(object):
             p, data = common.getMP(data)
             q, data = common.getMP(data)
             return cls(RSA.construct((n, e, d, p, q, u)))
-        else:
+        else:  # pragma: no cover
             raise BadKeyError("unknown key type %r" % (keyType[:30],))
 
     def _toString_AGENTV3(self):
@@ -1321,7 +1310,7 @@ class Key(object):
                 self._packMPSSHCOM(data['y']) +
                 self._packMPSSHCOM(data['x'])
                 )
-        else:
+        else:  # pragma: no cover
             raise BadKeyError('Unsupported key type %s' % type)
 
         payload_blob = common.NS(payload_blob)
@@ -1568,7 +1557,7 @@ class Key(object):
                 common.MP(data['y'])
                 )
             private_blob = common.MP(data['x'])
-        else:
+        else:  # pragma: no cover
             raise BadKeyError('Unsupported key type.')
 
         private_blob_plain = private_blob

--- a/chevah/keycert/tests/keydata.py
+++ b/chevah/keycert/tests/keydata.py
@@ -59,6 +59,9 @@ pSTqy7c3a2AScC/YyOwkDaICHnnD3XyjMwIxALRzl0tQEKMXs6hH8ToUdlLROCrP
 EhQ0wahUTCk1gKA4uPD6TMTChavbh4K63OvbKg==
 -----END RSA PRIVATE KEY-----"""
 
+privateRSA_fingerprint_md5 = (
+    b'3d:13:5f:cb:c9:79:8a:93:06:27:65:bc:3d:0b:8f:af')
+
 # some versions of OpenSSH generate these (slightly different keys)
 privateRSA_openssh_alternate = """-----BEGIN RSA PRIVATE KEY-----
 MIIBzjCCAcgCAQACYQCvMnHw5g6cmbN/i18ES8uLwNU+snf9z2TYj8DPrh/GMd/2

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -429,6 +429,16 @@ class TestKey(EmpiricalTestCase):
         self.assertRaises(RuntimeError, keys.Key(self).type)
         self.assertRaises(RuntimeError, keys.Key(self).sshType)
 
+    def test_generate_no_key_type(self):
+        """
+        An error is raised when generating a key with unknown type.
+        """
+        with self.assertRaises(KeyCertException) as context:
+            Key.generate(key_type=None)
+
+        self.assertEqual(
+            'Unknown key type "not-specified".', context.exception.message)
+
     def test_generate_unknown_type(self):
         """
         An error is raised when generating a key with unknown type.
@@ -1623,6 +1633,17 @@ IGNORED
         reloaded = Key.fromString(result)
         self.assertEqual(sut, reloaded)
 
+    def test_toString_PUTTY_public(self):
+        """
+        Can export to public RSA Putty.
+        """
+        sut = Key.fromString(OPENSSH_RSA_PRIVATE).public()
+
+        result = sut.toString(type='putty')
+
+        reloaded = Key.fromString(result)
+        self.assertEqual(sut, reloaded)
+
     def test_fromString_LSH(self):
         """
         Test that keys are correctly generated from LSH strings.
@@ -1678,6 +1699,15 @@ IGNORED
             keys.BadKeyError,
             keys.Key.fromString,
             '\x00\x00\x00\x07ssh-foo' + '\x00\x00\x00\x01\x01' * 5)
+
+    def test_fingerpint(self):
+        """
+        Will return the md5 fingerprint with colons separator.
+        """
+        key = keys.Key.fromString(keydata.privateRSA_openssh)
+
+        result = key.fingerprint()
+        self.assertEqual(keydata.privateRSA_fingerprint_md5, result)
 
     def test_sign(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
             'mock',
             'bunch',
             'coverage',
-            'coveralls',
+            'codecov',
             ],
         },
     cmdclass={'test': NoseTestCommand},


### PR DESCRIPTION
Scope
======

This works on improving the (reported) coverage in ssh code.

Changes
=======

Remove unused code for ssh alias properties.

Explicit add no-cover for code which should not be touched.

Under normal circumstance, we should not keep code which should not be called in production and leave it to fail with an ugly error.. also under normal circumstance you could not instanciante a key of unknown type.

I still kept the current code as it will help when we add a new key type.

As a drive by I switched to using codecov ... as it provide a nicer service.--

codecov has:

* nice diff view
* chrome extension 
* multi builder support / builder aggregation

How to test
=========

reviewers: @brunogola 

check that changes make sense.

this is also to let you know that I prefer codecov :)

Thanks!
 