### PR TITLE
[#2547] Fail when a passphrase was given for an unencrypted key.

### DIFF
--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -780,6 +780,8 @@ class Key(object):
             removeLen = ord(keyData[-1:])
             keyData = keyData[:-removeLen]
         else:
+            if passphrase:
+                raise BadKeyError('OpenSSH key not encrypted')
             b64Data = b''.join(lines[1:-1])
             keyData = base64.decodestring(b64Data)
 
@@ -1178,13 +1180,12 @@ class Key(object):
         cipher_type, rest = common.getNS(rest)
         encrypted_blob, _ = common.getNS(rest)
 
-        if cipher_type.lower() not in [b'none', b'3des-cbc']:
-            raise BadKeyError(
-                'Encryption method not supported: %r' % (
-                    cipher_type[:30]))
-
         encryption_key = None
-        if cipher_type.lower() == b'3des-cbc':
+        if cipher_type.lower() == b'none':
+            if passphrase:
+                raise BadKeyError('SSH.com key not encrypted')
+            key_data = encrypted_blob
+        elif cipher_type.lower() == b'3des-cbc':
             if not passphrase:
                 raise EncryptedKeyError(
                     'Passphrase must be provided for an encrypted key.')
@@ -1193,8 +1194,9 @@ class Key(object):
                 encryption_key, mode=DES3.MODE_CBC, IV=b'\x00' * 8).decrypt(
                 encrypted_blob)
         else:
-            # No encryption.
-            key_data = encrypted_blob
+            raise BadKeyError(
+                'Encryption method not supported: %r' % (
+                    cipher_type[:30]))
 
         try:
             payload, _ = common.getNS(key_data)
@@ -1427,7 +1429,10 @@ class Key(object):
 
         encryption_type = lines[1][11:].strip().lower()
 
-        if encryption_type not in [b'none', b'aes256-cbc']:
+        if encryption_type == b'none':
+            if passphrase:
+                raise BadKeyError('PuTTY key not encrypted')
+        elif encryption_type != b'aes256-cbc':
             raise BadKeyError(
                 'Unsupported encryption type: %r' % encryption_type[:30])
 

--- a/chevah/keycert/ssh.py
+++ b/chevah/keycert/ssh.py
@@ -1159,7 +1159,9 @@ class Key(object):
 
         @type data: C{bytes}
         @return: A {Crypto.PublicKey.pubkey.pubkey} object
-        @raises BadKeyError: if the blob type is unknown.
+        @raises BadKeyError: if
+            * the blob type is unknown.
+            * a passphrase is provided for an unencrypted key
         """
         blob = cls._getSSHCOMKeyContent(data)
         magic_number = struct.unpack('>I', blob[:4])[0]

--- a/chevah/keycert/tests/test_ssh.py
+++ b/chevah/keycert/tests/test_ssh.py
@@ -1017,6 +1017,19 @@ SUrCyZXsNh6VXwjs3gKQ
             passphrase='testxp')
         self.assertEqual(key, key2)
 
+    def test_fromString_PRIVATE_OPENSSH_not_encrypted_with_passphrase(self):
+        """
+        When loading a unencrypted OpenSSH private key with passhphrase
+        will raise BadKeyError.
+        """
+
+        with self.assertRaises(BadKeyError) as context:
+            Key.fromString(OPENSSH_RSA_PRIVATE, passphrase='pass')
+
+        self.assertEqual(
+            'OpenSSH key not encrypted',
+            context.exception.message)
+
     def test_toString_OPENSSH(self):
         """
         Test that the Key object generates OpenSSH keys correctly.
@@ -1307,6 +1320,19 @@ AAAAB3NzaC1yc2EA
 
         self.assertKeyParseError(content)
 
+    def test_fromString_PRIVATE_SSHCOM_unencrypted_with_passphrase(self):
+        """
+        When loading a unencrypted SSH.com private key with passhphrase
+        will raise BadKeyError.
+        """
+
+        with self.assertRaises(BadKeyError) as context:
+            Key.fromString(SSHCOM_RSA_PRIVATE_NO_PASSWORD, passphrase='pass')
+
+        self.assertEqual(
+            'SSH.com key not encrypted',
+            context.exception.message)
+
     def test_fromString_PRIVATE_SSHCOM_RSA_no_headers_no_password(self):
         """
         Can load a private SSH.com key which has no headers and no password.
@@ -1449,6 +1475,18 @@ P2/56wAAAi4AAAA3aWYtbW9kbntzaWdue3JzYS1wa2NzMS1zaGExfSxlbmNyeXB0e3JzYS
         sut = Key.fromString(PUTTY_RSA_PRIVATE_NO_PASSWORD)
 
         self.checkParsedRSAPrivate1024(sut)
+
+    def test_fromString_PRIVATE_PUTTY_not_encrypted_with_passphrase(self):
+        """
+        When loading a unencrypted PuTTY private key with passhphrase
+        will raise BadKeyError.
+        """
+        with self.assertRaises(BadKeyError) as context:
+            Key.fromString(PUTTY_RSA_PRIVATE_NO_PASSWORD, passphrase='pass')
+
+        self.assertEqual(
+            'PuTTY key not encrypted',
+            context.exception.message)
 
     def test_fromString_PRIVATE_PUTTY_RSA_with_password(self):
         """


### PR DESCRIPTION
Problem description
===================

The behavior is not consistent between public and private keys.

When loading an unencrypted public key but giving a passphrase, it raises BadKeyError, the same doesn't happen with private keys.


Changes description
===================

I added some tests to check for this behavior. 
Now when loading an unencrypted key with a passphrase it will raise a BadKeyError.


How to try and test the changes
===============================

reviewers: @adiroiban 

Check if changes make sense.

Also would be nice to test the server against this keycert branch, to check that when importing a private key, it will give a proper error message as well.