### PR TITLE
Fix the namespace declaration.

### DIFF
--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Relese notes for Chevah KeyCert
 ###############################
 
 
+1.4.4 - 25/01/2017
+==================
+
+* Release withtou changes to test the fix from 1.4.3.
+
+
 1.4.3 - 25/01/2017
 ==================
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Relese notes for Chevah KeyCert
 ###############################
 
 
+1.4.3 - 25/01/2017
+==================
+
+* Fix setup.py to declare the namespace package.
+
+
 1.4.2 - 06/01/2017
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,8 @@ setup(
 
     keywords='twisted ssh ssl tls pki ca',
 
+    namespace_packages=['chevah'],
+
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.4.2'
+VERSION = '1.4.3'
 
 
 class NoseTestCommand(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.4.3'
+VERSION = '1.4.4'
 
 
 class NoseTestCommand(TestCommand):


### PR DESCRIPTION
Scope
=====

This fix an error with chevah-keycert package upgrade where pip fails.

Changes
=========

declare the namespace package in setup.py

How to test
==========

reviewers: @brunogola 

latest version should be release and we should see that it can be successfully upgraded....

now the upgrade might fail since the previous version was broken... but we can release 1.4.4 and see that the upgrade and downgrade between these versions is smooth 
