### PR TITLE
Add support for stronger self signed certificates.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,19 @@
+Scope
+=====
+
+Describe the scope of the changes or the problem that these changes wants
+to solve.
+
+
+Changes
+=======
+
+Describe at a very high level how the problem was fixed.
+
+
+How to try and test the changes
+===============================
+
+reviewers: @robi-net
+
+Briefly describe the end user changes in a tester friendly way.

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -5,6 +5,7 @@ SSL keys and certificates.
 """
 from socket import gethostname
 import os
+from random import randint
 
 from OpenSSL import crypto
 
@@ -14,14 +15,21 @@ from chevah.keycert.exceptions import KeyCertException
 _DEFAULT_SSL_KEY_CYPHER = b'aes-256-cbc'
 
 
-def generate_ssl_self_signed_certificate(serial=1000):
+def generate_ssl_self_signed_certificate(options):
     """
     Generate a self signed SSL certificate.
 
     Returns a tuple of (certificate_pem, key_pem)
     """
+    serial = options.serial
+    key_size = options.key_size
+    sign_algorithm = options.sign_algorithm
+
+    if not serial:
+        serial = randint(0, 1000000000000)
+
     key = crypto.PKey()
-    key.generate_key(crypto.TYPE_RSA, 1024)
+    key.generate_key(crypto.TYPE_RSA, key_size)
 
     # create a self-signed cert
     cert = crypto.X509()
@@ -36,7 +44,7 @@ def generate_ssl_self_signed_certificate(serial=1000):
     cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(key)
-    cert.sign(key, 'sha1')
+    cert.sign(key, sign_algorithm)
 
     certificate_pem = crypto.dump_certificate(crypto.FILETYPE_PEM, cert)
     key_pem = crypto.dump_privatekey(crypto.FILETYPE_PEM, key)

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -5,6 +5,7 @@ Test for SSL keys/cert management.
 """
 from argparse import ArgumentParser
 
+from bunch import Bunch
 from chevah.compat.testing import mk, ChevahTestCase
 from OpenSSL import crypto
 
@@ -59,14 +60,19 @@ class Test_generate_ssl_self_signed_certificate(ChevahTestCase):
         Will generate the key and self signed certificate for current
         hostname.
         """
-        cert_pem, key_pem = generate_ssl_self_signed_certificate()
+        options = Bunch(
+            serial=0,
+            key_size=1024,
+            sign_algorithm='sha1'
+            )
+        cert_pem, key_pem = generate_ssl_self_signed_certificate(options)
 
         key = crypto.load_privatekey(crypto.FILETYPE_PEM, key_pem)
         cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_pem)
         self.assertEqual(1024, key.bits())
         self.assertEqual(crypto.TYPE_RSA, key.type())
-        subject = cert.get_subject()
-        self.assertEqual(u'UN', subject.C)
+        self.assertEqual(u'UN', cert.get_subject().C)
+        self.assertNotEqual(0, cert.get_serial_number())
         issuer = cert.get_issuer()
         self.assertEqual(cert.subject_name_hash(), issuer.hash())
 

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -18,6 +18,7 @@ from chevah.keycert.ssh import (
 from chevah.keycert.ssl import (
     generate_csr_parser,
     generate_and_store_csr,
+    generate_ssl_self_signed_certificate,
     )
 
 def ssh_load_key(options, open_method=None):
@@ -73,6 +74,34 @@ sub.set_defaults(handler=ssh_load_key)
 
 sub = generate_csr_parser(subparser, 'ssl-gen-key')
 sub.set_defaults(handler=generate_and_store_csr)
+
+
+sub = subparser.add_parser(
+    'ssl-self-signed',
+    help='Generate a self signed certificate.',
+    )
+sub.add_argument(
+    '--serial',
+    type=int,
+    default=1234,
+    metavar='DECIMAL_NUMBER',
+    help='Serial number for the self signed certificate.'
+    )
+sub.add_argument(
+    '--key-size',
+    type=int,
+    default=1024,
+    metavar='BITS',
+    help='Size of the newly generated ssl key.'
+    )
+sub.add_argument(
+    '--sign-algorithm',
+    default='sha1',
+    metavar='DECIMAL_NUMBER',
+    help='Serial number for the self signed certificate.'
+    )
+sub.set_defaults(handler=lambda o: print(
+    '\n'.join(generate_ssl_self_signed_certificate(o))))
 
 options = parser.parse_args()
 

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -97,8 +97,8 @@ sub.add_argument(
 sub.add_argument(
     '--sign-algorithm',
     default='sha1',
-    metavar='DECIMAL_NUMBER',
-    help='Serial number for the self signed certificate.'
+    metavar='STRING',
+    help='Algorithm used for the self-signed certificate: sha1, sha256, etc.'
     )
 sub.set_defaults(handler=lambda o: print(
     '\n'.join(generate_ssl_self_signed_certificate(o))))

--- a/pavement.py
+++ b/pavement.py
@@ -37,31 +37,13 @@ def test():
     """
     import nose
 
-    coverage = load_entry_point('coverage', 'console_scripts', 'coverage')
-
     nose_args = ['nosetests']
     nose_args.extend([
-        '--with-coverage',
-        '--cover-package=chevah.keycert',
-        '--cover-erase',
-        '--cover-test',
         ])
     nose_code = nose.run(argv=nose_args)
     nose_code = 0 if nose_code else 1
 
-    coverage_args = [
-        'report',
-        '--include=chevah/keycert/tests/*',
-        '--fail-under=100',
-        ]
-    covergate_exit = coverage(argv=coverage_args)
-    if not covergate_exit:
-        print('Tests coverage OK')
-
-    coverage(argv=['html', '-d', 'build/cover'])
-    print("See HTML coverate in build/cover")
-
-    sys.exit(nose_code or covergate_exit)
+    sys.exit(nose_code)
 
 
 @task

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.16.17804ad2:solaris10@2.7.8.17804ad2'
+BASE_REQUIREMENTS='chevah-brink==0.72.0 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.18.4b61bd67:sol10@2.7.8.4b61bd67'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -248,22 +248,28 @@ set_download_commands() {
     set +o errexit
     command -v wget > /dev/null
     if [ $? -eq 0 ]; then
-        set -o errexit
         # Using WGET for downloading Python package.
+        wget --version > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            # This is not GNU Wget, could be the more frugal wget from Busybox.
+            DOWNLOAD_CMD="wget"
+        else
+            # Use 1MB dots to reduce output and avoid polluting Buildbot pages.
+            DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
+        fi
         ONLINETEST_CMD="wget --spider --quiet"
-        # Use 1MB dots to reduce output, avoiding polluting Buildbot's pages.
-        DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
+        set -o errexit
         return
     fi
     command -v curl > /dev/null
     if [ $? -eq 0 ]; then
-        set -o errexit
         # Using CURL for downloading Python package.
-        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
         DOWNLOAD_CMD="curl --remote-name"
+        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
+        set -o errexit
         return
     fi
-    (>&2 echo "Missing wget/curl! One of them is needed for online operations.")
+    (>&2 echo "Missing wget and curl! One is needed for online operations.")
     exit 3
 }
 
@@ -502,7 +508,7 @@ check_os_version() {
         exit 12
     fi
 
-    # Using '.' as a delimiter, populate the version_raw_* arrays.
+    # Using '.' as a delimiter, populate the version_* arrays.
     IFS=. read -a version_raw_array <<< "$version_raw"
     IFS=. read -a version_good_array <<< "$version_good"
 
@@ -649,20 +655,6 @@ detect_os() {
                             "$os_version_raw" os_version_chevah
                         set_os_if_not_generic "amzn" $os_version_chevah
                         ;;
-                    sles)
-                        os_version_raw="$VERSION_ID"
-                        check_os_version "SUSE Linux Enterprise Server" 11 \
-                            "$os_version_raw" os_version_chevah
-                        # SLES 11 has OpenSSL 0.9.8, Security Module only adds
-                        # 1.0.1, so we use generic builds with included OpenSSL.
-                        if [ "$os_version_chevah" -eq 11 ]; then
-                            # We support this, so no need for check_linux_glibc,
-                            # As it has oldest glibc version among our slaves,
-                            # we use it for building generic Linux runtimes.
-                            OS="lnx"
-                        fi
-                        set_os_if_not_generic "sles" $os_version_chevah
-                        ;;
                     ubuntu|ubuntu-core)
                         os_version_raw="$VERSION_ID"
                         # 12.04/14.04 have OpenSSL 1.0.1, use generic Linux.
@@ -676,13 +668,6 @@ detect_os() {
                         fi
                         set_os_if_not_generic "ubuntu" $os_version_chevah
                         ;;
-                    debian)
-                        os_version_raw="$VERSION_ID"
-                        # Debian 7/8 have OpenSSL 1.0.1, use generic Linux.
-                        check_os_version "$distro_fancy_name" 9 \
-                            "$os_version_raw" os_version_chevah
-                        set_os_if_not_generic "debian" $os_version_chevah
-                        ;;
                     alpine)
                         os_version_raw="$VERSION_ID"
                         check_os_version "$distro_fancy_name" 3.6 \
@@ -690,7 +675,7 @@ detect_os() {
                         set_os_if_not_generic "alpine" $os_version_chevah
                         ;;
                     *)
-                        # Unsupported modern distros, such as Arch Linux.
+                        # Unsupported modern distros such as SLES, Debian, etc.
                         check_linux_glibc
                         ;;
                 esac
@@ -699,19 +684,12 @@ detect_os() {
         Darwin)
             ARCH=$(uname -m)
             os_version_raw=$(sw_vers -productVersion)
-            check_os_version "Mac OS X" 10.8 "$os_version_raw" os_version_chevah
-            if [ ${os_version_chevah:0:2} -eq 10 -a \
-                ${os_version_chevah:2:2} -ge 13 ]; then
-                # For macOS 10.13 or newer we use 'macos'.
-                OS="macos"
-            elif [ ${os_version_chevah:0:2} -eq 10 -a \
-                ${os_version_chevah:2:2} -ge 8 ]; then
-                # For macOS 10.12 and OS X 10.8-10.11 we use 'osx'.
-                OS="osx"
-            else
-                (>&2 echo "Unsupported Mac OS X version: $os_version_raw.")
-                exit 17
-            fi
+            # Tested on 10.13, but this works on 10.12 too. Older versions need
+            # "-Wl,-no_weak_imports" in LDFLAGS to avoid runtime issues. More
+            # details at https://github.com/Homebrew/homebrew-core/issues/3727.
+            check_os_version "macOS" 10.12 "$os_version_raw" os_version_chevah
+            # Build a generic package to cover all supported versions.
+            OS="macos"
             ;;
         FreeBSD)
             ARCH=$(uname -m)
@@ -780,10 +758,16 @@ detect_os() {
         "amd64"|"x86_64")
             ARCH="x64"
             case "$OS" in
-                win|sol10)
-                    # On Windows, only 32bit builds are currently supported.
+                sol10*)
                     # On Solaris 10, x64 built fine prior to adding "bcrypt".
                     ARCH="x86"
+                    ;;
+                win)
+                    # 32bit build on Windows 2016, 64bit otherwise.
+                    win_ver=$(systeminfo.exe | grep "OS Name" | cut -b 28-56)
+                    if [ "$win_ver" = "Microsoft Windows Server 2016" ]; then
+                        ARCH="x86"
+                    fi
                     ;;
             esac
             ;;

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for Chevah KeyCert
 ################################
 
 
+1.10.0 - 2020-05-12
+===================
+
+* Add support for configurable key size and signing algorithm when creating
+  a self signed certificate.
+
+
 1.9.3 - 2019-10-24
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.9.3'
+VERSION = '1.10.0'
 
 
 class NoseTestCommand(TestCommand):


### PR DESCRIPTION
Scope
=====

This updates the self signed certificate helper to create certificates with stronger keys and sign algoirhm.


Changes
=======

add option for key size and key algorihm.

As a drive by, I added the PR template for github.


How to test
========

reviewers: @dumol 

You can use the helper script at
```
./build/venv/bin/python keycert-demo.py ssl-self-signed --help
```

It will just output the cert and private key.. and you can then see if they are what you are expecting :)