### PR TITLE
Create a self signed certificate with custom attributes.

### DIFF
--- a/brink.conf
+++ b/brink.conf
@@ -1,5 +1,5 @@
 # We are using paver as replacement for Makefile
-BASE_REQUIREMENTS='chevah-brink==0.74.0 paver==1.2.4'
+BASE_REQUIREMENTS='chevah-brink==0.74.2 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.18.4b61bd67:sol10@2.7.8.4b61bd67'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -39,9 +39,17 @@ def generate_ssl_self_signed_certificate(options):
 
     Returns a tuple of (certificate_pem, key_pem)
     """
-    key_size = options.key_size
-    sign_algorithm = options.sign_algorithm
-    key_usage = options.key_usage.lower()
+    common_name = options.common_name
+
+    key_size = getattr(options, 'key_size', 2048)
+    sign_algorithm = getattr(options, 'sign_algorithm', 'sha256')
+    key_usage = getattr(options, 'key_usage', '').lower()
+    alternative_name = getattr(options, 'alternative_name', '')
+    country = getattr(options, 'country', '')
+    state = getattr(options, 'state', '')
+    locality = getattr(options, 'locality', '')
+    organization = getattr(options, 'organization', '')
+    organization_unit = getattr(options, 'organization_unit', '')
 
     serial = randint(0, 1000000000000)
 
@@ -51,22 +59,22 @@ def generate_ssl_self_signed_certificate(options):
     # create a self-signed cert
     cert = crypto.X509()
 
-    cert.get_subject().CN = options.common_name.encode('idna')
+    cert.get_subject().CN = common_name.encode('idna')
 
-    if options.country:
-        cert.get_subject().C = options.country.encode('ascii')
+    if country:
+        cert.get_subject().C = country.encode('ascii')
 
-    if options.state:
-        cert.get_subject().ST = options.state.encode('ascii')
+    if state:
+        cert.get_subject().ST = state.encode('ascii')
 
-    if options.locality:
-        cert.get_subject().L = options.locality.encode('ascii')
+    if locality:
+        cert.get_subject().L = locality.encode('ascii')
 
-    if options.organization:
-        cert.get_subject().O = options.organization.encode('ascii')
+    if organization:
+        cert.get_subject().O = organization.encode('ascii')
 
-    if options.organization_unit:
-        cert.get_subject().OU = options.organization_unit.encode('ascii')
+    if organization_unit:
+        cert.get_subject().OU = organization_unit.encode('ascii')
 
     critical_usage = False
     standard_usage = []
@@ -102,11 +110,11 @@ def generate_ssl_self_signed_certificate(options):
             ))
 
     # Alternate name is optional.
-    if options.alternative_name:
+    if alternative_name:
         extensions.append(crypto.X509Extension(
             b'subjectAltName',
             False,
-            options.alternative_name.encode('idna')))
+            alternative_name.encode('idna')))
     cert.add_extensions(extensions)
 
     cert.set_serial_number(serial)

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -60,8 +60,8 @@ def _generate_self_csr_parser(sub_command, default_key_size):
         '--key-usage',
         default='',
         help=(
-            'Comma separated key usage. '
-            'The following usage extension are supported: %s. '
+            'Comma-separated key usage. '
+            'The following key usage extensions are supported: %s. '
             'To mark usage as critical, prefix the values with `critical,`. '
             'For example: "critical,key-agreement,digital-signature".'
             ) % (', '.join(
@@ -72,8 +72,8 @@ def _generate_self_csr_parser(sub_command, default_key_size):
         '--constraints',
         default='',
         help=(
-            'Comma separated basic constraints. '
-            'To mark the constraints as critical, prefix the values with '
+            'Comma-separated basic constraints. '
+            'To mark constraints as critical, prefix the values with '
             '`critical,`. '
             'For example: "critical,CA:TRUE,pathlen:0".'
             ),
@@ -112,7 +112,7 @@ def _generate_self_csr_parser(sub_command, default_key_size):
     sub_command.add_argument(
         '--country',
         help=(
-            'Two letter code of the country.'),
+            'Two-letter country code.'),
         )
 
 
@@ -124,7 +124,7 @@ def generate_csr_parser(subparsers, name, default_key_size=2048):
     sub_command = subparsers.add_parser(
         name,
         help=(
-            'Create a SSL private key and associated certificate '
+            'Create an SSL private key and an associated certificate '
             'signing request.'),
         )
 
@@ -142,10 +142,10 @@ def generate_csr_parser(subparsers, name, default_key_size=2048):
         metavar="FILE",
         default='server.key',
         help=(
-            'Store the keys/csr pair in FILE and FILE.csr. '
+            'Store the keys/CSR pair in FILE and FILE.csr. '
             'Private key stored using PEM PKCS#8 format. '
             'CSR file stored in PEM x509 format. '
-            'Default server.key and server.csr.'),
+            'Default names: server.key and server.csr.'),
         )
 
     sub_command.add_argument(
@@ -169,8 +169,8 @@ def generate_self_signed_parser(subparsers, name, default_key_size=2048):
     sub_command = subparsers.add_parser(
         name,
         help=(
-            'Create a SSL private key '
-            'and associated self signed certificate.'),
+            'Create an SSL private key '
+            'and an associated self-signed certificate.'),
         )
     _generate_self_csr_parser(sub_command, default_key_size)
     return sub_command

--- a/chevah/keycert/ssl.py
+++ b/chevah/keycert/ssl.py
@@ -193,7 +193,7 @@ def generate_csr(options):
         raise KeyCertException(message)
 
 
-def  _set_subject_and_extensions(target, options):
+def _set_subject_and_extensions(target, options):
     """
     Set the subject and option for `target` CRS or certificate.
     """
@@ -345,6 +345,7 @@ def _generate_csr(options):
         'csr': csr,
         'key': key,
         }
+
 
 def generate_ssl_self_signed_certificate(options):
     """

--- a/chevah/keycert/tests/test_ssl.py
+++ b/chevah/keycert/tests/test_ssl.py
@@ -151,6 +151,9 @@ class Test_generate_csr_parser(
             'locality': None,
             'state': None,
             'country': None,
+            'constraints': '',
+            'key_usage': '',
+            'sign_algorithm': 'sha256',
             }, options)
 
     def test_value(self):
@@ -172,6 +175,9 @@ class Test_generate_csr_parser(
             '--locality=somewhere',
             '--state=without',
             '--country=GB',
+            '--constraints=critical,CA:FALSE',
+            '--key-usage=crl-sign',
+            '--sign-algorithm=sha1',
             ])
 
         self.assertNamespaceEqual({
@@ -188,6 +194,10 @@ class Test_generate_csr_parser(
             'locality': 'somewhere',
             'state': 'without',
             'country': 'GB',
+            'constraints': 'critical,CA:FALSE',
+            'key_usage': 'crl-sign',
+            'sign_algorithm': 'sha1',
+
             }, options)
 
     def test_default_overwrite(self):
@@ -218,6 +228,9 @@ class Test_generate_csr_parser(
             'locality': None,
             'state': None,
             'country': None,
+            'constraints': '',
+            'key_usage': '',
+            'sign_algorithm': 'sha256',
             }, options)
 
 

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -1,7 +1,7 @@
 """
 Demo command line for chevah-keycert.
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 # Fix namespaced package import.
 import chevah
 import os
@@ -18,6 +18,7 @@ from chevah.keycert.ssh import (
 from chevah.keycert.ssl import (
     generate_csr_parser,
     generate_and_store_csr,
+    generate_self_signed_parser,
     generate_ssl_self_signed_certificate,
     )
 
@@ -77,33 +78,9 @@ sub.set_defaults(handler=ssh_load_key)
 sub = generate_csr_parser(subparser, 'ssl-gen-key')
 sub.set_defaults(handler=generate_and_store_csr)
 
-
-sub = subparser.add_parser(
-    'ssl-self-signed',
-    help='Generate a self signed certificate.',
-    )
-sub.add_argument(
-    '--serial',
-    type=int,
-    default=1234,
-    metavar='DECIMAL_NUMBER',
-    help='Serial number for the self signed certificate.'
-    )
-sub.add_argument(
-    '--key-size',
-    type=int,
-    default=1024,
-    metavar='BITS',
-    help='Size of the newly generated ssl key.'
-    )
-sub.add_argument(
-    '--sign-algorithm',
-    default='sha1',
-    metavar='STRING',
-    help='Algorithm used for the self-signed certificate: sha1, sha256, etc.'
-    )
-sub.set_defaults(handler=lambda o: print(
-    '\n'.join(generate_ssl_self_signed_certificate(o))))
+sub = generate_self_signed_parser(subparser, 'ssl-self-signed')
+sub.set_defaults(handler=lambda o:
+    b'\n'.join(generate_ssl_self_signed_certificate(o)))
 
 options = parser.parse_args()
 

--- a/keycert-demo.py
+++ b/keycert-demo.py
@@ -75,8 +75,12 @@ sub.add_argument(
     )
 sub.set_defaults(handler=ssh_load_key)
 
-sub = generate_csr_parser(subparser, 'ssl-gen-key')
-sub.set_defaults(handler=generate_and_store_csr)
+sub = generate_csr_parser(subparser, 'ssl-csr')
+sub.set_defaults(handler=lambda o: (
+    generate_and_store_csr(o)
+    or print('CSR generated in files.')
+    or ''
+    ))
 
 sub = generate_self_signed_parser(subparser, 'ssl-self-signed')
 sub.set_defaults(handler=lambda o:

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for Chevah KeyCert
 ################################
 
 
+1.12.0 - 2020-07-06
+===================
+
+* Allow creating self signed certificate with various attributes.
+
+
 1.11.1 - 2020-07-02
 ===================
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for Chevah KeyCert
 ################################
 
 
+1.12.2 - 2020-07-09
+===================
+
+* Update command line help messages.
+
+
 1.12.1 - 2020-07-06
 ===================
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for Chevah KeyCert
 ################################
 
 
+1.12.1 - 2020-07-06
+===================
+
+* Allow defining key usage and constraints for CSR and self signed certificate
+  generation.
+
+
 1.12.0 - 2020-07-06
 ===================
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -5,14 +5,14 @@ Release notes for Chevah KeyCert
 1.12.1 - 2020-07-06
 ===================
 
-* Allow defining key usage and constraints for CSR and self signed certificate
-  generation.
+* Allow defining key usage and constraints for Certificate Signing Requests
+  and self-signed certificates.
 
 
 1.12.0 - 2020-07-06
 ===================
 
-* Allow creating self signed certificate with various attributes.
+* Allow creating self-signed certificates with custom attributes.
 
 
 1.11.1 - 2020-07-02

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.12.1'
+VERSION = '1.12.2'
 
 
 class NoseTestCommand(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.11.0'
+VERSION = '1.12.0'
 
 
 class NoseTestCommand(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkg_resources import load_entry_point
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-VERSION = '1.12.0'
+VERSION = '1.12.1'
 
 
 class NoseTestCommand(TestCommand):


### PR DESCRIPTION
Scope
=====

This add support to create a self signed certificate with custom attributes.

In previous version the self signed certificate was created with random serial number, but using a fixed set of attributes.


Changes
=======

Add command line argument parser.

Refactored the code to allow for defining key usage and constraints for the CSR generation.

The demo script was updated to have extra options when create a self signed certificate/


How to try and test the changes
===============================

reviewers: @dumol 


1.Self signed cert generation
---------------------------------------


To check the command line options and documentation:

```
$ ./build-keycert/bin/python keycert-demo.py ssl-self-signed --help
```

From the command line I was using he following one liner to generate the cert and then parse it with openssl:


```
$ ./build-keycert/bin/python keycert-demo.py ssl-self-signed --common-name=test --key-usage=critical,key-cert-sign,server-authentication --alternative-name=IP:1.2.3.4,DNS:tol.com --constraints=critical,CA:FALSE | openssl x509 -text

```


2.CSR generation
---------------------------------------


To check the command line options and documentation:

```
$ ./build-keycert/bin/python keycert-demo.py ssl-csr --help
```

To generate a new csr... first delete exiting one, then generate csr and then decode with openssh

```
$ rm server.*
$ ./build-keycert/bin/python keycert-demo.py ssl-csr --common-name bla
$ cat server.csr | openssl req -text
```